### PR TITLE
trim white space of text answers

### DIFF
--- a/js/qsm-admin-question.js
+++ b/js/qsm-admin-question.js
@@ -289,7 +289,7 @@ var import_button;
                                     var ta_id = $answer.find('textarea').attr('id')
                                     answer = wp.editor.getContent( ta_id );                                    
                                 }else{
-                                    answer = $answer.find( '.answer-text' ).val();
+                                    answer = $answer.find( '.answer-text' ).val().trim();
                                 }
 				
 				var points = $answer.find( '.answer-points' ).val();


### PR DESCRIPTION
White space at the end of text answers can lead to incorrect evaluation, as has also been reported in the answer of issue #841.

When entering/updating answers, applying `trim()` to answer strings just before saving them, can reliably prevent this issue.