### PR TITLE
Removes nl2br functionality from email and results pages.

### DIFF
--- a/php/classes/class-qsm-emails.php
+++ b/php/classes/class-qsm-emails.php
@@ -163,7 +163,6 @@ class QSM_Emails {
 		$content = htmlspecialchars_decode( $content, ENT_QUOTES );                
                 $response_data['email_template_array'] = true;
 		$content = apply_filters( 'mlw_qmn_template_variable_results_page', $content, $response_data );
-		$content = str_replace( "\n", '<br>', $content );
 		$content = str_replace( '<br/>', '<br>', $content );
 		$content = str_replace( '<br />', '<br>', $content );
 		$content = html_entity_decode( $content );

--- a/php/classes/class-qsm-results-pages.php
+++ b/php/classes/class-qsm-results-pages.php
@@ -148,8 +148,7 @@ class QSM_Results_Pages {
 			// Decodes special characters, runs through our template
 			// variables, and then outputs the text.
 			$page = htmlspecialchars_decode( $content, ENT_QUOTES );
-			$page = apply_filters( 'mlw_qmn_template_variable_results_page', $page, $response_data );
-			echo str_replace( "\n", '<br>', $page );
+			echo apply_filters( 'mlw_qmn_template_variable_results_page', $page, $response_data );
 			do_action( 'qsm_after_results_page' );
 			?>
 		</div>


### PR DESCRIPTION
See #820 

The WYSIWYG editor is built to input HTML (or at least it converts input to HTML), so it doesn't make sense to substitute new lines with the `<br>` tag in either of these instances. It most cases, the added `<br>` tags result in broken email and results page layouts.