### PR TITLE
Cu-bfeypn: preferred date format settings

### DIFF
--- a/php/admin/settings-page.php
+++ b/php/admin/settings-page.php
@@ -111,7 +111,8 @@ class QMNGlobalSettingsPage {
 		add_settings_field( 'disable-description-on-quiz-result-page', __( 'Disable description on quiz result page?', 'quiz-master-next' ), array( $this, 'qsm_global_disable_description_on_quiz_result_page' ), 'qsm_default_global_option', 'qmn-global-section' );
 		add_settings_field( 'disable-scroll-on-next-and-previous-button-click', __( 'Disable scroll on next and previous button click?', 'quiz-master-next' ), array( $this, 'qsm_global_disable_scroll_on_next_and_previous_button_click' ), 'qsm_default_global_option', 'qmn-global-section' );
 		add_settings_field( 'quiz-animation', __( 'Quiz Animation', 'quiz-master-next' ), array( $this, 'qsm_global_quiz_animation' ), 'qsm_default_global_option', 'qmn-global-section' );
-		add_settings_field( 'logo-url', __( 'Logo URL', 'quiz-master-next' ), array( $this, 'qsm_global_logo_url' ), 'qsm_default_global_option', 'qmn-global-section' );		
+		add_settings_field( 'logo-url', __( 'Logo URL', 'quiz-master-next' ), array( $this, 'qsm_global_logo_url' ), 'qsm_default_global_option', 'qmn-global-section' );
+		add_settings_field( 'preferred_date_format', __( 'Preferred Date Format', 'quiz-master-next' ), array( $this, 'preferred_date_format' ), 'qsm_default_global_option', 'qmn-global-section' );
 		global $globalQuizsetting;
 		$globalQuizsetting=get_option( 'qsm-quiz-settings' );
 
@@ -1107,6 +1108,20 @@ class QMNGlobalSettingsPage {
 				<input type="checkbox" id="not_allow_after_expired_time-1" name="qsm-quiz-settings[not_allow_after_expired_time]" value="1" '. checked( $qsm_not_allow_after_expired_time, '1', false ) .'>
 				<br>
 			</fieldset>';
+	}
+
+	/**
+	 * Generates quiz global field for preferred date format
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	public function preferred_date_format() {
+		
+		global $globalQuizsetting;
+		$preferred_date_format =(isset($globalQuizsetting['preferred_date_format'])? $globalQuizsetting['preferred_date_format'] : get_option( 'date_format' ));
+		echo '<input type="text" id="preferred_date_format" name="qsm-quiz-settings[preferred_date_format]" value="'.$preferred_date_format.'">';
+		echo '<span class="qsm-opt-desc">Set your preferred date format.</span>';
 	}
 	
 	

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -1455,6 +1455,42 @@ public function load_questions( $quiz_id, $quiz_options, $is_quiz_page, $questio
 			}
 			$qmn_array_for_variables['result_id'] = $results_id;
 
+			//Converts date to the preferred format
+			$qsm_qna_list = $qmn_array_for_variables['question_answers_array'];
+			$qsm_quiz_settings = unserialize($qmn_quiz_options->quiz_settings);
+			$qsm_quiz_options=unserialize($qsm_quiz_settings['quiz_options']);
+			$qsm_global_settings = get_option( 'qsm-quiz-settings' );
+			foreach ($qsm_qna_list as $qna_id => $qna){
+				if ("12"===$qna['question_type']){
+
+					//check if preferred date format is set at quiz level or plugin level. Default to WP date format otherwise
+					$preferred_date_format= isset($qsm_quiz_options['preferred_date_format'])? $qsm_quiz_options['preferred_date_format'] : (isset($qsm_global_settings['preferred_date_format'])? $qsm_global_settings['preferred_date_format'] : get_option( 'date_format'));
+
+					//filter date format
+					$GLOBALS['qsm_date_format']= apply_filters('qms_preferred_date_format', $preferred_date_format );
+
+					if(null!==$GLOBALS['qsm_date_format']){
+						$qmn_array_for_variables['question_answers_array'][$qna_id]['1']= date_i18n( $GLOBALS['qsm_date_format'], strtotime(($qna['1'])));
+						// $qmn_array_for_variables['question_answers_array'][$qna_id]['2']=  date_i18n( $GLOBALS['qsm_date_format'], strtotime(($qna['2'])));	
+					}
+
+					//converts the questions array into preferred date format for question type date
+					function qsm_convert_question_array_date_format($questions){	
+						foreach ($questions as $question_id => $question_to_convert){
+							if("12"=== $question_to_convert['question_type_new']){
+								foreach ($question_to_convert['answers'] as $answer_id => $answer_value){
+									if(1===$answer_value[2] && null!==$GLOBALS['qsm_date_format']){										
+										$questions[$question_id]['answers'][$answer_id][0]= date_i18n( $GLOBALS['qsm_date_format'], strtotime($answer_value[0]));
+									}
+								}	
+							}
+						}
+						return $questions;
+					}
+					add_filter( 'qsm_load_questions_by_pages','qsm_convert_question_array_date_format');
+				}
+			}			
+
 			// Determines redirect/results page.
 			$results_pages   = $this->display_results_text( $qmn_quiz_options, $qmn_array_for_variables );
 			$result_display .= $results_pages['display'];

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -1475,18 +1475,20 @@ public function load_questions( $quiz_id, $quiz_options, $is_quiz_page, $questio
 					}
 
 					//converts the questions array into preferred date format for question type date
-					function qsm_convert_question_array_date_format($questions){	
-						foreach ($questions as $question_id => $question_to_convert){
-							if("12"=== $question_to_convert['question_type_new']){
-								foreach ($question_to_convert['answers'] as $answer_id => $answer_value){
-									if(1===$answer_value[2] && null!==$GLOBALS['qsm_date_format']){										
-										$questions[$question_id]['answers'][$answer_id][0]= date_i18n( $GLOBALS['qsm_date_format'], strtotime($answer_value[0]));
-									}
-								}	
+					if(!function_exists('qsm_convert_question_array_date_format')){
+						function qsm_convert_question_array_date_format($questions){	
+							foreach ($questions as $question_id => $question_to_convert){
+								if("12"=== $question_to_convert['question_type_new']){
+									foreach ($question_to_convert['answers'] as $answer_id => $answer_value){
+										if(1===$answer_value[2] && null!==$GLOBALS['qsm_date_format']){										
+											$questions[$question_id]['answers'][$answer_id][0]= date_i18n( $GLOBALS['qsm_date_format'], strtotime($answer_value[0]));
+										}
+									}	
+								}
 							}
+							return $questions;
 						}
-						return $questions;
-					}
+					} 
 					add_filter( 'qsm_load_questions_by_pages','qsm_convert_question_array_date_format');
 				}
 			}			

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -1471,7 +1471,7 @@ public function load_questions( $quiz_id, $quiz_options, $is_quiz_page, $questio
 
 					if(null!==$GLOBALS['qsm_date_format']){
 						$qmn_array_for_variables['question_answers_array'][$qna_id]['1']= date_i18n( $GLOBALS['qsm_date_format'], strtotime(($qna['1'])));
-						// $qmn_array_for_variables['question_answers_array'][$qna_id]['2']=  date_i18n( $GLOBALS['qsm_date_format'], strtotime(($qna['2'])));	
+						$qmn_array_for_variables['question_answers_array'][$qna_id]['2']=  date_i18n( $GLOBALS['qsm_date_format'], strtotime(($qna['2'])));	
 					}
 
 					//converts the questions array into preferred date format for question type date

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -1480,7 +1480,7 @@ public function load_questions( $quiz_id, $quiz_options, $is_quiz_page, $questio
 							foreach ($questions as $question_id => $question_to_convert){
 								if("12"=== $question_to_convert['question_type_new']){
 									foreach ($question_to_convert['answers'] as $answer_id => $answer_value){
-										if(1===$answer_value[2] && null!==$GLOBALS['qsm_date_format']){										
+										if( null!==$GLOBALS['qsm_date_format']){										
 											$questions[$question_id]['answers'][$answer_id][0]= date_i18n( $GLOBALS['qsm_date_format'], strtotime($answer_value[0]));
 										}
 									}	

--- a/php/classes/class-qsm-install.php
+++ b/php/classes/class-qsm-install.php
@@ -709,6 +709,16 @@ class QSM_Install {
 			'help'    => __( 'If left blank, this will default to QSM logo', 'quiz-master-next' ),
 		);
 		$mlwQuizMasterNext->pluginHelper->register_quiz_setting( $field_array, 'quiz_options' );
+
+		// Registers Preferred date type settings in the quiz options
+		$field_array = array(
+			'id'      => 'preferred_date_format',
+			'label'   => __( 'Preferred Date Format', 'quiz-master-next' ),
+			'type'    => 'text',
+			'default' => isset(get_option( 'qsm-quiz-settings' )['preferred_date_format'])? get_option( 'qsm-quiz-settings' )['preferred_date_format'] : get_option( 'date_format'),
+			'help'    => __( 'Overrides gloabl settings for preferred date format', 'quiz-master-next' ),
+		);
+		$mlwQuizMasterNext->pluginHelper->register_quiz_setting( $field_array, 'quiz_options' );
 		do_action( 'qsm_extra_setting_fields' );
 		// Setting for animation
 		$field_array = array(


### PR DESCRIPTION
Introduces preferred date format settings at global and quiz which takes standard _format string_ as the input. Output of the date format question is converted to preferred date format before displaying and sending email.