### PR TITLE
Fix: Filter "mlw_qmn_admin_results_page_headings" no longer works properly

### DIFF
--- a/php/admin/admin-results-page.php
+++ b/php/admin/admin-results-page.php
@@ -337,7 +337,7 @@ if ( isset($_POST["results-screen_option_nonce"]) && wp_verify_nonce( sanitize_t
 	<input type="hidden" name="bulk_permanent_delete" id="bulk_permanent_delete" value="0" />
 	<?php wp_nonce_field( 'bulk_delete', 'bulk_delete_nonce' );
 
-	$th_elements = apply_filters( 'mlw_qmn_admin_results_page_headings', array(
+	$th_elements = array(
 		'score'         => __( 'Score', 'quiz-master-next' ),
 		'time_complete' => __( 'Time To Complete', 'quiz-master-next' ),
 		'name'          => __( 'Name', 'quiz-master-next' ),
@@ -349,12 +349,19 @@ if ( isset($_POST["results-screen_option_nonce"]) && wp_verify_nonce( sanitize_t
 		'ip'            => __( 'IP Address', 'quiz-master-next' ),
 		'page_name'     => __( 'Page Name', 'quiz-master-next' ),
 		'page_url'      => __( 'Page URL', 'quiz-master-next' ),
-	) );
+	);
 
 	$values = $quiz_infos = [];
 	foreach ( $th_elements as $key => $th ) {
 		$values[ $key ]['title'] = $th;
 		$values[ $key ]['style'] = "";
+	}
+
+	$custom_th_elements = apply_filters( 'mlw_qmn_admin_results_page_headings', array() );
+	foreach ( $custom_th_elements as $key => $th ) {
+		$values[ $key ]['title'] = $th;
+		$values[ $key ]['style'] = "";
+		$values[ $key ]['content'] = "custom";
 	}
 
 	$display_none = ' style=display:none; ';

--- a/php/admin/admin-results-page.php
+++ b/php/admin/admin-results-page.php
@@ -337,7 +337,7 @@ if ( isset($_POST["results-screen_option_nonce"]) && wp_verify_nonce( sanitize_t
 	<input type="hidden" name="bulk_permanent_delete" id="bulk_permanent_delete" value="0" />
 	<?php wp_nonce_field( 'bulk_delete', 'bulk_delete_nonce' );
 
-	$th_elements = array(
+	$th_elements = apply_filters( 'mlw_qmn_admin_results_page_headings', array(
 		'score'         => __( 'Score', 'quiz-master-next' ),
 		'time_complete' => __( 'Time To Complete', 'quiz-master-next' ),
 		'name'          => __( 'Name', 'quiz-master-next' ),
@@ -349,7 +349,7 @@ if ( isset($_POST["results-screen_option_nonce"]) && wp_verify_nonce( sanitize_t
 		'ip'            => __( 'IP Address', 'quiz-master-next' ),
 		'page_name'     => __( 'Page Name', 'quiz-master-next' ),
 		'page_url'      => __( 'Page URL', 'quiz-master-next' ),
-	);
+	) );
 
 	$values = $quiz_infos = [];
 	foreach ( $th_elements as $key => $th ) {
@@ -357,7 +357,7 @@ if ( isset($_POST["results-screen_option_nonce"]) && wp_verify_nonce( sanitize_t
 		$values[ $key ]['style'] = "";
 	}
 
-	$custom_th_elements = apply_filters( 'mlw_qmn_admin_results_page_headings', array() );
+	$custom_th_elements = apply_filters( 'mlw_qmn_admin_results_page_custom_headings', array() );
 	foreach ( $custom_th_elements as $key => $th ) {
 		$values[ $key ]['title'] = $th;
 		$values[ $key ]['style'] = "";


### PR DESCRIPTION
## Site Info
WordPress Version: 5.8.3
QSM Version: 7.3.9
Browser: Chrome

## General description
In the past, I submitted a pull request to add the mlw_qmn_admin_results_page_headings filter. It worked well before, but in the new version of the plugin (with the refactor into a php array vs an html block) it doesn't work for custom values passed in.

The reason why is on line 476 of quiz-master-next/php/admin/admin-results-page.php

```
if ( ! empty( $v['content'] ) ) {
    echo '<th'. esc_html( $v['style'] ) . '>'. esc_html( $v['title'] ) . '</th>';
}
```
This if check checks for that content array attribute, but there's no way for me to pass it, so none of my values actually have it.

I updated the way that the th elements var works, so that it merges the filtered default list and a filtered custom list, and for the ones in the custom list, it will just set their content to "custom" so that they pass that not-empty content check.
