### PR TITLE
Admin Notification for database permission ALTER TABLE, enable error log by default, retrieve failed submission

### DIFF
--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -336,6 +336,28 @@ class MLWQuizMasterNext {
 		add_action( 'admin_init', array( $this, 'qsm_overide_old_setting_options' ) );
 		add_action( 'admin_notices', array( $this, 'qsm_admin_notices' ) );
 		add_filter( 'manage_edit-qsm_category_columns', array( $this, 'modify_qsm_category_columns' ) );
+		add_action( 'admin_init', array( $this, 'has_alter_table_issue_solved' ), 999 );
+	}
+
+	/**
+	 * Check if alter table issue has been solved by trying failed alter table query
+	 * 
+	 * @since 9.0.2
+	 * 
+	 * @return void
+	 */
+	public function has_alter_table_issue_solved() {
+		// Get failed alter table query list.
+		$failed_queries = $this->get_failed_alter_table_queries();
+		if ( ! empty( $failed_queries ) ) {
+			foreach ( $failed_queries as $failed_query ) {
+				$failed_query = $this->wpdb_alter_table_query( $failed_query );
+				// exit loop if query failed to execute
+				if ( false === $failed_query ) {
+					break;
+				}
+			}
+		}
 	}
 
 	/**

--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -853,7 +853,7 @@ class MLWQuizMasterNext {
 
 		// Get failed alter table query list.
 		$failed_queries = $this->get_failed_alter_table_queries();
-		if ( ! empty( $failed_queries ) && is_array( $failed_queries )  && 0 < count( $failed_queries ) ) {
+		if ( ! empty( $failed_queries ) && 0 < count( $failed_queries ) ) {
 			?>
 			<div class="notice notice-warning is-dismissible qmn-database-user-incorrect-permission">
 				<p><?php esc_html_e( "It seems your database user doesn't have permission to ALTER TABLE. Please ensure the necessary permissions are in place or contact your hosting provider.", "quiz-master-next" ); ?></p>

--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -720,6 +720,10 @@ class MLWQuizMasterNext {
 			}
 			add_submenu_page( 'options.php', __( 'Settings', 'quiz-master-next' ), __( 'Settings', 'quiz-master-next' ), 'edit_posts', 'mlw_quiz_options', 'qsm_generate_quiz_options' );
 			add_submenu_page( 'qsm_dashboard', __( 'Results', 'quiz-master-next' ), __( 'Results', 'quiz-master-next' ), 'moderate_comments', 'mlw_quiz_results', 'qsm_generate_admin_results_page' );
+			
+			// Failed Submission.
+			add_submenu_page( 'qsm_dashboard', __( 'Failed Submission', 'quiz-master-next' ), __( 'Failed Submission', 'quiz-master-next' ), 'moderate_comments', 'mlw_quiz_failed_submission', array( $this,'admin_failed_submission_page' ) );
+			
 			add_submenu_page( 'options.php', __( 'Result Details', 'quiz-master-next' ), __( 'Result Details', 'quiz-master-next' ), 'moderate_comments', 'qsm_quiz_result_details', 'qsm_generate_result_details' );
 			add_submenu_page( 'qsm_dashboard', __( 'Settings', 'quiz-master-next' ), __( 'Settings', 'quiz-master-next' ), 'manage_options', 'qmn_global_settings', array( 'QMNGlobalSettingsPage', 'display_page' ) );
 			add_submenu_page( 'qsm_dashboard', __( 'Tools', 'quiz-master-next' ), __( 'Tools', 'quiz-master-next' ), 'manage_options', 'qsm_quiz_tools', 'qsm_generate_quiz_tools' );
@@ -732,6 +736,26 @@ class MLWQuizMasterNext {
 			}
 			// Register screen option for dashboard page
 			add_action( 'screen_settings', 'qsm_dashboard_screen_options', 10, 2 );
+		}
+	}
+
+	/**
+	 * Failed Submission Table
+	 *
+	 * Display failed submission table.
+	 *
+	 * @since 9.0.2
+	 * @return void
+	 */
+	public function admin_failed_submission_page() {
+		$file_path = trailingslashit( plugin_dir_path( __FILE__ ) ) . 'php/admin/class-failed-submission.php';
+		if ( file_exists( $file_path ) ) {
+			include_once $file_path;
+			if ( ! class_exists( 'QmnFailedSubmissions' ) ) {
+				return; 
+			}
+			$QmnFailedSubmissions = new QmnFailedSubmissions();
+			$QmnFailedSubmissions->render_list_table();
 		}
 	}
 
@@ -807,9 +831,9 @@ class MLWQuizMasterNext {
 
 		// Get failed alter table query list.
 		$failed_queries = $this->get_failed_alter_table_queries();
-		if ( ! empty( $failed_queries ) && 0 < count( $failed_queries ) ) {
+		if ( ! empty( $failed_queries ) && is_array( $failed_queries )  && 0 < count( $failed_queries ) ) {
 			?>
-			<div class="notice notice-warning qmn-database-user-incorrect-permission">
+			<div class="notice notice-warning is-dismissible qmn-database-user-incorrect-permission">
 				<p><?php esc_html_e( "It seems your database user doesn't have permission to ALTER TABLE. Please ensure the necessary permissions are in place or contact your hosting provider.", "quiz-master-next" ); ?></p>
 			</div>
 			<?php

--- a/php/admin/class-failed-submission.php
+++ b/php/admin/class-failed-submission.php
@@ -56,6 +56,7 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 				array(
 					'post_type'      => 'qmn_log',
 					'meta_key'       => $this->meta_key,
+					'post_status'	 => 'publish',
 					'fields'         => 'ids',
 					'posts_per_page' => -1,
 				)
@@ -63,14 +64,12 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 
 			$posts    = empty( $posts ) ? array() : $posts;
 			$per_page = 20;
-			// Total rows.
-			$this->total_rows = count( $posts );
 			if ( ! empty( $posts ) ) {
 				$current_page       = intval( $this->get_pagenum() ) - 1;
 				$post_start_postion = $per_page * $current_page;
 
 				foreach ( $posts as $index => $postID ) {
-					if ( $post_start_postion > $index || $index > ( $post_start_postion + $per_page ) ) {
+					if ( $post_start_postion > $index || $index >= ( $post_start_postion + $per_page ) ) {
 						continue;
 					}
 					$data = get_post_meta( $postID, $this->meta_key, true );
@@ -89,7 +88,7 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 			// pagination.
 			$this->set_pagination_args(
 				array(
-					'total_items' => $this->total_rows,
+					'total_items' =>  count( $posts ),
 					'per_page'    => $per_page,
 				)
 			);
@@ -101,6 +100,8 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 			$this->_column_headers = array(
 				$this->get_columns(),
 				$this->get_hidden_columns(),
+				array(), // Sortable column
+				'cb', // Primary column
 			);
 		}
 

--- a/php/admin/class-failed-submission.php
+++ b/php/admin/class-failed-submission.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Creates the failed submission page within the admin area
+ *
+ * @package QSM
+ * @since 9.0.2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Abort if the class is already exists.
+ */
+if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' ) ) {
+	/**
+	 * This class display failed submission list table
+	 *
+	 * @since 9.0.2
+	 */
+	class QmnFailedSubmissions extends WP_List_Table {
+
+		/**
+		 * Holds meta_key name
+		 *
+		 * @var object
+		 * @since 9.0.2
+		 */
+		public $meta_key = '_qmn_log_result_insert_data';
+
+		/**
+		 * Holds table_data
+		 *
+		 * @var object
+		 * @since 9.0.2
+		 */
+		private $table_data = array();
+
+		public function __construct() {
+			parent::__construct(
+				array(
+					'plural'   => 'submissions',
+					'singular' => 'submission',
+					'ajax'     => false,
+				)
+			);
+		}
+
+		/**
+		 * Prepares the list of items for displaying.
+		 */
+		public function prepare_items() {
+			// QMN Error log.
+			$posts = get_posts(
+				array(
+					'post_type'      => 'qmn_log',
+					'meta_key'       => $this->meta_key,
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				)
+			);
+
+			$posts    = empty( $posts ) ? array() : $posts;
+			$per_page = 20;
+			// Total rows.
+			$this->total_rows = count( $posts );
+			if ( ! empty( $posts ) ) {
+				$current_page       = intval( $this->get_pagenum() ) - 1;
+				$post_start_postion = $per_page * $current_page;
+
+				foreach ( $posts as $index => $postID ) {
+					if ( $post_start_postion > $index || $index > ( $post_start_postion + $per_page ) ) {
+						continue;
+					}
+					$data = get_post_meta( $postID, $this->meta_key, true );
+					if ( empty( $data ) ) {
+						continue;
+					}
+					$data = maybe_unserialize( $data );
+					if ( ! is_array( $data ) || ! empty( $data['deleted'] ) || empty( $data['qmn_array_for_variables'] ) ) {
+						continue;
+					}
+					$data['qmn_array_for_variables']['post_id'] = $postID;
+					$this->table_data[]                         = $data['qmn_array_for_variables'];
+				}
+			}
+
+			// pagination.
+			$this->set_pagination_args(
+				array(
+					'total_items' => $this->total_rows,
+					'per_page'    => $per_page,
+				)
+			);
+
+			// table data.
+			$this->items = $this->table_data;
+
+			// table headers.
+			$this->_column_headers = array(
+				$this->get_columns(),
+				$this->get_hidden_columns(),
+			);
+		}
+
+		/**
+		 * Gets a list of columns.
+		 *
+		 * @return array
+		 */
+		public function get_columns() {
+			return array(
+				'cb'                => '<input type="checkbox" />',
+				'post_id'           => __( 'ID', 'quiz-master-next' ),
+				'quiz_name'         => __( 'Quiz Name', 'quiz-master-next' ),
+				'user_name'         => __( 'Name', 'quiz-master-next' ),
+				'user_email'        => __( 'Email', 'quiz-master-next' ),
+				'submission_action' => __( 'Action', 'quiz-master-next' ),
+			);
+		}
+
+		/**
+		 * Gets a list of hidden columns.
+		 *
+		 * @return array
+		 */
+		public function get_hidden_columns() {
+			return array(
+				'post_id',
+			);
+		}
+
+		public function column_cb( $submission ) {
+			return sprintf(
+				'<input type="checkbox" name="post_id[]" value="%d" /> ',
+				$submission['post_id']
+			);
+		}
+
+		public function column_default( $submission, $column_name ) {
+			$column_value = '';
+			switch ( $column_name ) {
+				case 'post_id':
+					$column_value = $submission['post_id'];
+					break;
+				case 'quiz_name':
+					$column_value = $submission['quiz_name'];
+					break;
+				case 'user_name':
+					$column_value = $submission['user_name'];
+					break;
+				case 'user_email':
+					$column_value = $submission['user_email'];
+					break;
+				case 'submission_action':
+					$column_value = '<a href="' . esc_url( admin_url( 'admin.php?action=retrieve&post_id=' . esc_attr( $submission['post_id'] ) . '&qmnnonce=' . wp_create_nonce( 'qmn_failed_submission' ) ) ) . '" class="qmn-delete-failed-submission" >' . __( 'Retrieve', 'quiz-master-next' ) . '</a>';
+					break;
+				default:
+					break;
+			}
+
+			return $column_value;
+		}
+
+		public function get_bulk_actions() {
+			return array(
+				'retrieve' => __( 'Retrieve', 'quiz-master-next' ),
+				'trash'    => __( 'Delete', 'quiz-master-next' ),
+			);
+		}
+
+		/**
+		 * Render page with this table
+		 *
+		 * @param class $store
+		 */
+		public function render_list_table() {
+
+			$this->prepare_items();
+			// header.
+			echo '<div class="qmn-failed-submission wrap">';
+			// heading.
+			echo '<h2 id="result_details" >' . esc_html__( 'Failed Submissions', 'quiz-master-next' ) . '</h2>';
+			// body.
+			echo '<div class="qmn-body">';
+			echo "<form method='post' name='search_form' action='" . esc_url( admin_url( 'admin.php?page=mlw_quiz_failed_submission' ) ) . "'>";
+			echo '<div class="submission-filter-wrapper" >';
+			$this->views();
+			echo '</div>';
+			echo '<input type="hidden" name="qmnnonce" value="' . wp_create_nonce( 'qmn_failed_submission' ) . '" />';
+			$this->display();
+			echo '</form>';
+			echo '</div>';
+			echo '</div>';
+		}
+	}
+}

--- a/php/admin/functions.php
+++ b/php/admin/functions.php
@@ -78,7 +78,7 @@ function qsm_add_author_column_in_db() {
 				);
 
 				if ( empty( $table_col_obj ) ) {
-					$wpdb->query( 'ALTER TABLE ' . $table . ' ADD ' . $col_name . ' ' . $col_def );
+					$mlwQuizMasterNext->wpdb_alter_table_query( 'ALTER TABLE ' . $table . ' ADD ' . $col_name . ' ' . $col_def );
 				}
 			}
 		}
@@ -96,7 +96,7 @@ function qsm_add_author_column_in_db() {
 			)
 		);
 		if ( empty( $table_result_col_obj ) ) {
-			if ( $wpdb->query( "ALTER TABLE $result_table_name ADD form_type INT NOT NULL" ) ) {
+			if ( $mlwQuizMasterNext->wpdb_alter_table_query( "ALTER TABLE $result_table_name ADD form_type INT NOT NULL" ) ) {
 				update_option( 'qsm_update_result_db_column', '1' );
 			} else {
 				$mlwQuizMasterNext->log_manager->add( 'Error Creating Column form_type in' . $result_table_name, "Tried {$wpdb->last_query} but got {$wpdb->last_error}.", 0, 'error' );
@@ -118,7 +118,7 @@ function qsm_add_author_column_in_db() {
 			)
 		);
 		if ( ! empty( $table_quiz_col_obj ) ) {
-			if ( $wpdb->query( "ALTER TABLE $quiz_table_name CHANGE `system` `quiz_system` INT(11) NOT NULL;" ) ) {
+			if ( $mlwQuizMasterNext->wpdb_alter_table_query( "ALTER TABLE $quiz_table_name CHANGE `system` `quiz_system` INT(11) NOT NULL;" ) ) {
 				update_option( 'qsm_update_quiz_db_column', '1' );
 			} else {
 				$mlwQuizMasterNext->log_manager->add( 'Error Changing Columns system,quiz_system in' . $quiz_table_name, "Tried {$wpdb->last_query} but got {$wpdb->last_error}.", 0, 'error' );
@@ -140,7 +140,7 @@ function qsm_add_author_column_in_db() {
 			), ARRAY_A
 		);
 		if ( isset( $table_quiz_result_obj['DATA_TYPE'] ) && 'text' === $table_quiz_result_obj['DATA_TYPE'] ) {
-			if ( $wpdb->query( "ALTER TABLE $result_table_name CHANGE `quiz_results` `quiz_results` LONGTEXT;" ) ) {
+			if ( $mlwQuizMasterNext->wpdb_alter_table_query( "ALTER TABLE $result_table_name CHANGE `quiz_results` `quiz_results` LONGTEXT;" ) ) {
 				update_option( 'qsm_update_result_db_column_datatype', '1' );
 			} else {
 				$mlwQuizMasterNext->log_manager->add( 'Error Changing Columns quiz_results in' . $result_table_name, "Tried {$wpdb->last_query} but got {$wpdb->last_error}.", 0, 'error' );
@@ -163,7 +163,7 @@ function qsm_add_author_column_in_db() {
 			)
 		);
 		if ( empty( $table_result_col_obj ) ) {
-			if ( $wpdb->query( "ALTER TABLE $question_table_name ADD deleted_question_bank INT NOT NULL" ) ) {
+			if ( $mlwQuizMasterNext->wpdb_alter_table_query( "ALTER TABLE $question_table_name ADD deleted_question_bank INT NOT NULL" ) ) {
 				$inc_val = $total_count_val + 1;
 				update_option( 'qsm_add_new_column_question_table_table', $inc_val );
 			} else {
@@ -185,7 +185,7 @@ function qsm_add_author_column_in_db() {
 			)
 		);
 		if ( empty( $table_result_col_obj ) ) {
-			if ( $wpdb->query( "ALTER TABLE $result_table_name ADD page_url varchar(255) NOT NULL" ) ) {
+			if ( $mlwQuizMasterNext->wpdb_alter_table_query( "ALTER TABLE $result_table_name ADD page_url varchar(255) NOT NULL" ) ) {
 				update_option( 'qsm_update_result_db_column_page_url', '1' );
 			} else {
 				$error = $wpdb->last_error;
@@ -208,7 +208,7 @@ function qsm_add_author_column_in_db() {
 			)
 		);
 		if ( empty( $table_result_col_obj ) ) {
-			if ( $wpdb->query( "ALTER TABLE $result_table_name ADD page_name varchar(255) NOT NULL" ) ) {
+			if ( $mlwQuizMasterNext->wpdb_alter_table_query( "ALTER TABLE $result_table_name ADD page_name varchar(255) NOT NULL" ) ) {
 				update_option( 'qsm_update_result_db_column_page_name', '1' );
 			} else {
 				$mlwQuizMasterNext->log_manager->add( 'Error Creating Column page_name in' . $result_table_name, "Tried {$wpdb->last_query} but got {$wpdb->last_error}.", 0, 'error' );
@@ -235,7 +235,7 @@ function qsm_add_author_column_in_db() {
 
 		foreach ( $tables_to_convert as $table ) {
 			$query = "ALTER TABLE $table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
-			$result = $wpdb->query($query);
+			$result = $mlwQuizMasterNext->wpdb_alter_table_query($query);
 
 			if ( ! $result ) {
 				$success = false;

--- a/php/classes/class-qmn-log-manager.php
+++ b/php/classes/class-qmn-log-manager.php
@@ -96,7 +96,7 @@ class QMN_Log_Manager
 	 * @param $type string The type of the log
 	 * @return bool|int False if error else id of the newly inserted post
 	 */
-	public function add( $title = '', $message = '', $parent = 0, $type = null ) {
+	public function add( $title = '', $message = '', $parent = 0, $type = null, $log_meta = null ) {
 		$log_data = array(
 			'post_title'   => $title,
 			'post_content' => $message,
@@ -105,7 +105,7 @@ class QMN_Log_Manager
 		);
 		$settings = (array) get_option( 'qmn-settings' );
         if ( ! empty( $settings['enable_qsm_log'] ) && $settings['enable_qsm_log'] ) {
-			return $this->insert_log( $log_data );
+			return $this->insert_log( $log_data, $log_meta );
 		}
 		return false;
 	}
@@ -117,7 +117,7 @@ class QMN_Log_Manager
 	 * @param $log_data Array of data about the log including title, message, and type
 	 * @return bool|int False if error else id of the newly inserted post
 	 */
-  	public function insert_log( $log_data = array() ) {
+  	public function insert_log( $log_data = array(), $log_meta = null ) {
 		$defaults = array(
 			'post_type'    => 'qmn_log',
 			'post_status'  => 'publish',

--- a/php/classes/class-qmn-log-manager.php
+++ b/php/classes/class-qmn-log-manager.php
@@ -104,10 +104,7 @@ class QMN_Log_Manager
 			'log_type'     => $type,
 		);
 		$settings = (array) get_option( 'qmn-settings' );
-        if ( ! empty( $settings['enable_qsm_log'] ) && $settings['enable_qsm_log'] ) {
-			return $this->insert_log( $log_data, $log_meta );
-		}
-		return false;
+		return $this->insert_log( $log_data, $log_meta );
 	}
 
 	/**

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -111,11 +111,11 @@ class QMNQuizManager {
 		if ( ! empty( $_REQUEST['post_id'] ) && ! empty( $_REQUEST['action'] ) && function_exists('is_admin') && is_admin() && ! empty( $_REQUEST['qmnnonce'] ) && wp_verify_nonce( wp_unslash( $_REQUEST['qmnnonce'] ), 'qmn_failed_submission' )  ) {
 			
 			$post_ids = wp_unslash( $_REQUEST['post_id'] );
-			$post_ids = is_array( $post_ids ) ? array_map( 'sanitize_key', $post_ids ) : sanitize_key( $post_ids );
+			$post_ids = is_array( $post_ids ) ? array_map( 'sanitize_key', $post_ids ) : array( sanitize_key( $post_ids ) );
 			$action = wp_unslash( sanitize_key( $_REQUEST['action'] ) );
 			if ( ! empty( $post_ids ) ) {
 				foreach ( $post_ids as $postID) {
-
+					
 					$postID = intval( $postID );
 
 					// Continue if postID not valid
@@ -175,6 +175,11 @@ class QMNQuizManager {
 			$data['deleted'] = 1;
 			// Delete submission data
 			update_post_meta( $postID, $this->meta_key, maybe_serialize( $data ) );
+			// Change Error log post status to trash
+			wp_update_post( array(
+				'ID'          => $postID,
+				'post_status' => 'trash',
+			) );
 		}
 	}
 

--- a/php/classes/class-qsm-install.php
+++ b/php/classes/class-qsm-install.php
@@ -1610,11 +1610,11 @@ class QSM_Install {
 			// Update 0.5
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'comment_section'" ) != 'comment_section' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD comment_field_text TEXT NOT NULL AFTER phone_field_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD comment_section INT NOT NULL AFTER admin_email';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD message_comment TEXT NOT NULL AFTER message_after';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET comment_field_text='Comments', comment_section=1, message_comment='Enter You Text Here'";
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1622,7 +1622,7 @@ class QSM_Install {
 			// Update 0.9.4
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'randomness_order'" ) != 'randomness_order' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD randomness_order INT NOT NULL AFTER system';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . ' SET randomness_order=0';
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1630,7 +1630,7 @@ class QSM_Install {
 			// Update 0.9.5
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_answer_template'" ) != 'question_answer_template' ) {
 				$sql                         = 'ALTER TABLE ' . $table_name . ' ADD question_answer_template TEXT NOT NULL AFTER comment_field_text';
-				$results                     = $wpdb->query( $sql );
+				$results                     = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$mlw_question_answer_default = '%QUESTION%<br /> Answer Provided: %USER_ANSWER%<br /> Correct Answer: %CORRECT_ANSWER%<br /> Comments Entered: %USER_COMMENTS%<br />';
 				$update_sql                  = 'UPDATE ' . $table_name . " SET question_answer_template='" . $mlw_question_answer_default . "'";
 				$results                     = $wpdb->query( $update_sql );
@@ -1639,7 +1639,7 @@ class QSM_Install {
 			// Update 0.9.6
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'contact_info_location'" ) != 'contact_info_location' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD contact_info_location INT NOT NULL AFTER send_admin_email';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . ' SET contact_info_location=0';
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1647,7 +1647,7 @@ class QSM_Install {
 			// Update 1.0
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'email_from_text'" ) != 'email_from_text' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD email_from_text TEXT NOT NULL AFTER comment_field_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET email_from_text='Wordpress'";
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1655,7 +1655,7 @@ class QSM_Install {
 			// Update 1.3.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'loggedin_user_contact'" ) != 'loggedin_user_contact' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD loggedin_user_contact INT NOT NULL AFTER randomness_order';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . ' SET loggedin_user_contact=0';
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1663,7 +1663,7 @@ class QSM_Install {
 			// Update 1.5.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_from_total'" ) != 'question_from_total' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD question_from_total INT NOT NULL AFTER comment_section';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . ' SET question_from_total=0';
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1671,13 +1671,13 @@ class QSM_Install {
 			// Update 1.6.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'total_user_tries'" ) != 'total_user_tries' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD total_user_tries INT NOT NULL AFTER question_from_total';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . ' SET total_user_tries=0';
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'total_user_tries_text'" ) != 'total_user_tries_text' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD total_user_tries_text TEXT NOT NULL AFTER total_user_tries';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET total_user_tries_text='Enter Your Text Here'";
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1685,13 +1685,13 @@ class QSM_Install {
 			// Update 1.8.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'message_end_template'" ) != 'message_end_template' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD message_end_template TEXT NOT NULL AFTER message_comment';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET message_end_template=''";
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'certificate_template'" ) != 'certificate_template' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD certificate_template TEXT NOT NULL AFTER total_user_tries_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET certificate_template='Enter your text here!'";
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1699,31 +1699,31 @@ class QSM_Install {
 			// Update 1.9.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'social_media'" ) != 'social_media' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD social_media INT NOT NULL AFTER certificate_template';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET social_media='0'";
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'social_media_text'" ) != 'social_media_text' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD social_media_text TEXT NOT NULL AFTER social_media';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET social_media_text='I just score a %CORRECT_SCORE%% on %QUIZ_NAME%!'";
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'pagination'" ) != 'pagination' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD pagination INT NOT NULL AFTER social_media_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . ' SET pagination=0';
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'pagination_text'" ) != 'pagination_text' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD pagination_text TEXT NOT NULL AFTER pagination';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET pagination_text='Next'";
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'timer_limit'" ) != 'timer_limit' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD timer_limit INT NOT NULL AFTER pagination_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . ' SET timer_limit=0';
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1731,7 +1731,7 @@ class QSM_Install {
 			// Update 2.1.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'quiz_stye'" ) != 'quiz_stye' ) {
 				$sql               = 'ALTER TABLE ' . $table_name . ' ADD quiz_stye TEXT NOT NULL AFTER timer_limit';
-				$results           = $wpdb->query( $sql );
+				$results           = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$mlw_style_default = '
   				div.mlw_qmn_quiz input[type=radio],
   				div.mlw_qmn_quiz input[type=submit],
@@ -1781,7 +1781,7 @@ class QSM_Install {
 			// Update 2.2.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_numbering'" ) != 'question_numbering' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD question_numbering INT NOT NULL AFTER quiz_stye';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET question_numbering='0'";
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1789,7 +1789,7 @@ class QSM_Install {
 			// Update 2.8.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'quiz_settings'" ) != 'quiz_settings' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD quiz_settings TEXT NOT NULL AFTER question_numbering';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET quiz_settings=''";
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1797,7 +1797,7 @@ class QSM_Install {
 			// Update 3.0.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'theme_selected'" ) != 'theme_selected' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD theme_selected TEXT NOT NULL AFTER quiz_settings';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET theme_selected='default'";
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1805,7 +1805,7 @@ class QSM_Install {
 			// Update 3.3.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'last_activity'" ) != 'last_activity' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD last_activity DATETIME NOT NULL AFTER theme_selected';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET last_activity='%s'", gmdate( 'Y-m-d H:i:s' ) );
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1813,25 +1813,25 @@ class QSM_Install {
 			// Update 3.5.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'require_log_in'" ) != 'require_log_in' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD require_log_in INT NOT NULL AFTER last_activity';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET require_log_in='%d'", '0' );
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'require_log_in_text'" ) != 'require_log_in_text' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD require_log_in_text TEXT NOT NULL AFTER require_log_in';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( 'UPDATE ' . $table_name . " SET require_log_in_text='%s'", 'Enter Text Here' );
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'limit_total_entries'" ) != 'limit_total_entries' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD limit_total_entries INT NOT NULL AFTER require_log_in_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET limit_total_entries='%d'", '0' );
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'limit_total_entries_text'" ) != 'limit_total_entries_text' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD limit_total_entries_text TEXT NOT NULL AFTER limit_total_entries';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET limit_total_entries_text='%s'", 'Enter Text Here' );
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1839,19 +1839,19 @@ class QSM_Install {
 			// Update 7.3.8
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'quiz_author_id'" ) != 'quiz_author_id' ) {
 				$sql     = 'ALTER TABLE ' . $table_name . ' ADD quiz_author_id TEXT NOT NULL AFTER deleted';
-				$results = $wpdb->query( $sql );
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 			}
 
 			// Update 3.7.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'scheduled_timeframe'" ) != 'scheduled_timeframe' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD scheduled_timeframe TEXT NOT NULL AFTER limit_total_entries_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET scheduled_timeframe=''";
 				$results    = $wpdb->query( stripslashes( esc_sql( $update_sql ) ) );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'scheduled_timeframe_text'" ) != 'scheduled_timeframe_text' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD scheduled_timeframe_text TEXT NOT NULL AFTER scheduled_timeframe';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET scheduled_timeframe_text='%s'", 'Enter Text Here' );
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1859,13 +1859,13 @@ class QSM_Install {
 			// Update 4.3.0
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'disable_answer_onselect'" ) != 'disable_answer_onselect' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD disable_answer_onselect INT NOT NULL AFTER scheduled_timeframe_text';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET disable_answer_onselect=%d", '0' );
 				$results    = $wpdb->query( $update_sql );
 			}
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'ajax_show_correct'" ) != 'ajax_show_correct' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD ajax_show_correct INT NOT NULL AFTER disable_answer_onselect';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET ajax_show_correct=%d", '0' );
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1875,23 +1875,23 @@ class QSM_Install {
 			// Update 0.5
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'comments'" ) != 'comments' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD comments INT NOT NULL AFTER correct_answer';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD hints TEXT NOT NULL AFTER comments';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET comments=%d, hints=''", '1' );
 				$results    = $wpdb->query( $update_sql );
 			}
 			// Update 0.8
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_order'" ) != 'question_order' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD question_order INT NOT NULL AFTER hints';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET question_order=%d", '0' );
 				$results    = $wpdb->query( $update_sql );
 			}
 
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_type'" ) != 'question_type' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD question_type INT NOT NULL AFTER question_order';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET question_type=%d", '0' );
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1899,7 +1899,7 @@ class QSM_Install {
 			// Update 1.1.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_answer_info'" ) != 'question_answer_info' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD question_answer_info TEXT NOT NULL AFTER correct_answer';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET question_answer_info=''";
 				$results    = $wpdb->query( stripslashes( esc_sql( $update_sql ) ) );
 			}
@@ -1907,7 +1907,7 @@ class QSM_Install {
 			// Update 2.5.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'answer_array'" ) != 'answer_array' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD answer_array TEXT NOT NULL AFTER question_name';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET answer_array=''";
 				$results    = $wpdb->query( stripslashes( esc_sql( $update_sql ) ) );
 			}
@@ -1915,7 +1915,7 @@ class QSM_Install {
 			// Update 3.1.1
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_settings'" ) != 'question_settings' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD question_settings TEXT NOT NULL AFTER question_type';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET question_settings=''";
 				$results    = $wpdb->query( stripslashes( esc_sql( $update_sql ) ) );
 			}
@@ -1923,7 +1923,7 @@ class QSM_Install {
 			// Update 4.0.0
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'category'" ) != 'category' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD category TEXT NOT NULL AFTER question_settings';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = 'UPDATE ' . $table_name . " SET category=''";
 				$results    = $wpdb->query( stripslashes( esc_sql( $update_sql ) ) );
 			}
@@ -1931,7 +1931,7 @@ class QSM_Install {
 			// Update 4.0.0
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'question_type_new'" ) != 'question_type_new' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD question_type_new TEXT NOT NULL AFTER question_type';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET question_type_new=%s", 'question_type' );
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1940,21 +1940,21 @@ class QSM_Install {
 			$user_email_template_data = $wpdb->get_row( 'SHOW COLUMNS FROM ' . $wpdb->prefix . "mlw_quizzes LIKE 'user_email_template'" );
 			if ( 'text' === $user_email_template_data->Type ) {
 				$sql     = 'ALTER TABLE ' . $wpdb->prefix . 'mlw_quizzes  MODIFY user_email_template LONGTEXT';
-				$results = $wpdb->query( $sql );
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 			}
 
 			// Update 7.3.11
 			$user_message_after_data = $wpdb->get_row( 'SHOW COLUMNS FROM ' . $wpdb->prefix . "mlw_quizzes LIKE 'message_after'" );
 			if ( 'text' === $user_message_after_data->Type ) {
 				$sql     = 'ALTER TABLE ' . $wpdb->prefix . 'mlw_quizzes MODIFY message_after LONGTEXT';
-				$results = $wpdb->query( $sql );
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 			}
 
 			// Update 2.6.1
-			$results = $wpdb->query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_qm_audit_trail CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;' );
-			$results = $wpdb->query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_questions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' );
-			$results = $wpdb->query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_quizzes CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' );
-			$results = $wpdb->query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_results CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' );
+			$results = $mlwQuizMasterNext->wpdb_alter_table_query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_qm_audit_trail CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;' );
+			$results = $mlwQuizMasterNext->wpdb_alter_table_query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_questions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' );
+			$results = $mlwQuizMasterNext->wpdb_alter_table_query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_quizzes CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' );
+			$results = $mlwQuizMasterNext->wpdb_alter_table_query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_results CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' );
 
 			global $wpdb;
 			$table_name  = $wpdb->prefix . 'mlw_results';
@@ -1963,7 +1963,7 @@ class QSM_Install {
 			// Update 2.6.4
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $table_name . " LIKE 'user'" ) != 'user' ) {
 				$sql        = 'ALTER TABLE ' . $table_name . ' ADD user INT NOT NULL AFTER phone';
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET user=%d", '0' );
 				$results    = $wpdb->query( $update_sql );
 			}
@@ -1971,23 +1971,23 @@ class QSM_Install {
 			// Update 4.7.0
 			if ( $wpdb->get_var( "SHOW COLUMNS FROM $table_name LIKE 'user_ip'" ) != 'user_ip' ) {
 				$sql        = "ALTER TABLE $table_name ADD user_ip TEXT NOT NULL AFTER user";
-				$results    = $wpdb->query( $sql );
+				$results    = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$update_sql = $wpdb->prepare( "UPDATE {$table_name} SET user_ip='%s'", 'Unknown' );
 				$results    = $wpdb->query( $update_sql );
 			}
 			// Update 7.1.11
 			$user_message_after_data = $wpdb->get_row( 'SHOW COLUMNS FROM ' . $wpdb->prefix . "mlw_results LIKE 'point_score'" );
 			if ( 'FLOAT' != $user_message_after_data->Type ) {
-				$results = $wpdb->query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_results MODIFY point_score FLOAT NOT NULL;' );
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query( 'ALTER TABLE ' . $wpdb->prefix . 'mlw_results MODIFY point_score FLOAT NOT NULL;' );
 			}
 
 			if ( $wpdb->get_var( 'SHOW COLUMNS FROM ' . $audit_table . " LIKE 'quiz_id'" ) != 'quiz_id' ) {
 				$sql     = 'ALTER TABLE ' . $audit_table . ' ADD quiz_id TEXT NOT NULL AFTER action';
-				$results = $wpdb->query( $sql );
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$sql     = 'ALTER TABLE ' . $audit_table . ' ADD quiz_name TEXT NOT NULL AFTER quiz_id';
-				$results = $wpdb->query( $sql );
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 				$sql     = 'ALTER TABLE ' . $audit_table . ' ADD form_data TEXT NOT NULL AFTER quiz_name';
-				$results = $wpdb->query( $sql );
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query( $sql );
 
 			}
 			// Update 5.0.0
@@ -2010,7 +2010,7 @@ class QSM_Install {
 
 			// Update 8.1.14
 			if ( ! $wpdb->query("SHOW KEYS FROM {$results_table_name} WHERE Key_name = 'unique_id_unique'" ) ) {
-				$results = $wpdb->query("ALTER TABLE {$results_table_name} ADD UNIQUE (unique_id)");
+				$results = $mlwQuizMasterNext->wpdb_alter_table_query("ALTER TABLE {$results_table_name} ADD UNIQUE (unique_id)");
 			}
 
 			// Update 8.0.3

--- a/readme.txt
+++ b/readme.txt
@@ -167,7 +167,7 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 * Bug: Fixed display shortcode php buffer due to invalid quiz id
 * Feature: Added Failed submission list in QSM menu
 * Feature: Added retrieve or delete failed submission
-* Enhancement: Added admin notification if database user does not has proper permission.
+* Enhancement: Added admin notification if database user does not have proper permission.
 
 = 9.0.1 (April 25, 2024) =
 * Bug: Fixed date format in %ANSWER_X% variable

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,9 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 == Changelog ==
 = 9.0.2 ( Beta ) =
 * Bug: Fixed display shortcode php buffer due to invalid quiz id
+* Feature: Added Failed submission list in QSM menu
+* Feature: Added retrieve or delete failed submission
+* Enhancement: Added admin notification if database user does not has proper permission.
 
 = 9.0.1 (April 25, 2024) =
 * Bug: Fixed date format in %ANSWER_X% variable


### PR DESCRIPTION
* Added Failed submission list in QSM menu
* Added retrieve or delete failed submission
* Added admin notification if database user does not have proper permission.
* Added failed submission as post_meta in error log custom post
* On retrieve failed submission error log post status change to trash
* Check if database permission issue solved on admin_init
* If database error occurs first 15 character can be seen as error_details  in web inspector > network


### Merge Checklist

Please check all of the following items before merging

- [ ] No new WPCS issues
- [ ] No notices, warnings or errors in debug.log
- [ ] No sonar cloud issues
- [ ] No errors while running automated tests
