### PR TITLE
Ajax, add date and ip column in failed submission admin dashboard table

### DIFF
--- a/css/qsm-admin.css
+++ b/css/qsm-admin.css
@@ -3437,3 +3437,11 @@ input#preferred-date-format-custom {
 	background: #cccccc36;
     border: 1px solid #ccc;
 }
+
+.qsm-pointer-events-none {
+	pointer-events: none;
+}
+
+.display-none-notice {
+	display: none;
+}

--- a/js/qsm-admin.js
+++ b/js/qsm-admin.js
@@ -3957,3 +3957,122 @@ var import_button;
     qsmHandleOperatorChange('email-condition', 'condition-default-value');
 
 }(jQuery));
+
+
+/**
+ * QSM - failed submission data table action
+ */
+(function ($) {
+    function submit_failed_submission_action_notice( res ) {
+        if ( 'object' !== typeof res || null === res || undefined === res.message  ) {
+            return false;
+        }
+       let noticeEl = $( '#qmn-failed-submission-table-message' );
+       if ( 0 < noticeEl.length ) {
+            let remove_notice_type_class = 'success' === res.status ? 'notice-error' : 'notice-success';
+            noticeEl.removeClass( remove_notice_type_class );
+            noticeEl.addClass( 'notice-'+res.status );
+            noticeEl.html(
+                '<p>'+res.message+'</p>'
+            );
+            noticeEl.show();
+            noticeEl.fadeOut( 9999 );
+       }
+    }
+
+    function submit_failed_submission_action_form( formData, ) {
+    
+        // check for required data
+        if ( undefined === formData || null === formData || -1 == formData.quiz_action || 0 === formData.post_ids.length ) {
+            submit_failed_submission_action_notice( {
+                status:"error",
+                message:"Missing form action or data"
+            } );
+            return false;
+        } 
+
+        // quiz action
+        formData.action = 'qsm_action_failed_submission_table';
+        
+        // Disable conatiner for further any action
+        let containerDiv = $("#qmn-failed-submission-conatiner");
+            containerDiv.toggleClass('qsm-pointer-events-none');
+        
+        // Actiion one by one
+        formData.post_ids.forEach( post_id => {
+            formData.post_id = post_id;
+            let action_link_wrap = $( '#action-link-'+post_id );
+            let action_link_html = action_link_wrap.html();
+            action_link_wrap.html( 'processing...');
+            $.ajax({
+                type: 'POST',
+                url: ajaxurl,
+                data: formData,
+                success: function (response) {
+                    // notice.
+                    submit_failed_submission_action_notice( response.data );
+                   
+                    // enable click pointer
+                    containerDiv.removeClass('qsm-pointer-events-none');
+
+                    // add success icon
+                    if ( response.success ) {
+                        action_link_wrap.html( '<span class="dashicons dashicons-yes-alt"></span>' );
+                    } else {
+                        action_link_wrap.html( action_link_html );
+                    }
+
+                    // Remove row if trashed
+                    if ( 'trash' === formData.quiz_action ) {
+                        $( '#qsm-submission-row-'+post_id ).remove();
+                    }
+                    
+                },
+                error: function ( jqXHR, textStatus, errorThrown ) {
+                    // undo action link 
+                    action_link_wrap.html( action_link_html );
+
+                    // enable click pointer
+                    containerDiv.removeClass('qsm-pointer-events-none');
+                    
+                    // error notice
+                    submit_failed_submission_action_notice( {
+                        status:"error",
+                        message:errorThrown
+                    } );
+                }
+            });
+        });
+
+    }
+
+    // Submit Form.
+    $( document ).on( 'submit', '#failed-submission-action-form', function( e ) {
+        e.preventDefault();
+        let formData = {
+            qmnnonce: $('#failed-submission-action-form input[name="qmnnonce"]').val(),
+            post_ids: [],
+            quiz_action: $('#failed-submission-action-form #bulk-action-selector-top').val()
+        };
+         // Select all checkboxes with the name attribute 'post_id[]'
+         let checkedCheckboxes = $('#failed-submission-action-form input[type="checkbox"][name="post_id[]"]:checked');
+
+         // Iterate over each checked checkbox
+         checkedCheckboxes.each(function() {
+            formData.post_ids.push( $(this).val() );
+         });
+         
+         submit_failed_submission_action_form( formData );
+    } );
+
+    // On click retrieve link
+    $( document ).on( 'click', '.qmn-retrieve-failed-submission-link', function( e ) {
+        e.preventDefault();
+        
+        submit_failed_submission_action_form( {
+            qmnnonce: $('#failed-submission-action-form input[name="qmnnonce"]').val(),
+            post_ids: [ $(this).attr('post-id') ],
+            quiz_action:'retrieve'
+        } );
+    } );
+}(jQuery));

--- a/php/admin/class-failed-submission.php
+++ b/php/admin/class-failed-submission.php
@@ -205,7 +205,9 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 		 *
 		 * @since 9.0.2
 		 *
-		 * @param object|array $item The current item
+		 * @param object|array $submission The current item
+		 * 
+		 * @return void
 		 */
 		public function single_row( $submission ) {
 			echo '<tr id="qsm-submission-row-' . esc_attr( $submission['post_id'] ) . '" >';

--- a/php/admin/class-failed-submission.php
+++ b/php/admin/class-failed-submission.php
@@ -84,6 +84,10 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 
 		/**
 		 * Prepares the list of items for displaying.
+		 * 
+		 *  @since 9.0.2
+		 * 
+		 *  @return void
 		 */
 		public function prepare_items() {
 			// QMN Error log.
@@ -146,8 +150,10 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 
 		/**
 		 * Gets a list of columns.
-		 *
-		 * @return array
+		 * 
+		 * @since 9.0.2
+		 * 
+		 * @return array columns list
 		 */
 		public function get_columns() {
 			$columns = array(
@@ -171,7 +177,9 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 		/**
 		 * Gets the list of views available on this table.
 		 *
-		 * @return array
+		 * @since 9.0.2
+		 * 
+		 * @return array tabs link
 		 */
 		protected function get_views() {
 			$views = array(
@@ -208,7 +216,9 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 		/**
 		 * Gets a list of hidden columns.
 		 *
-		 * @return array
+		 * @since 9.0.2
+		 * 
+		 * @return array hidden column name
 		 */
 		public function get_hidden_columns() {
 			return array(
@@ -216,6 +226,13 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 			);
 		}
 
+		/**
+		 * Checkbox to select submissions.
+		 *
+		 * @since 9.0.2
+		 * 
+		 * @return html input checkbox 
+		 */
 		public function column_cb( $submission ) {
 			return sprintf(
 				'<input type="checkbox" name="post_id[]" value="%d" /> ',
@@ -223,6 +240,13 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 			);
 		}
 
+		/**
+		 * Column value
+		 *
+		 * @since 9.0.2
+		 * 
+		 * @return string specific column value 
+		 */
 		public function column_default( $submission, $column_name ) {
 			$column_value = '';
 			switch ( $column_name ) {
@@ -260,6 +284,13 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 			return $column_value;
 		}
 
+		/**
+		 * Bulk action
+		 *
+		 * @since 9.0.2
+		 * 
+		 * @return array actions
+		 */
 		public function get_bulk_actions() {
 			return array(
 				'retrieve' => __( 'Retrieve', 'quiz-master-next' ),
@@ -270,7 +301,9 @@ if ( ! class_exists( 'QmnFailedSubmissions' ) && class_exists( 'WP_List_Table' )
 		/**
 		 * Render page with this table
 		 *
-		 * @param class $store
+		 * @since 9.0.2
+		 * 
+		 * @return HTML failed submission page
 		 */
 		public function render_list_table() {
 


### PR DESCRIPTION
following changes are done in submission table:

Use Ajax for action

Add column : IP, Date

Change "Retrieve" name to "Resubmit"

Add tabs of table -  Resubmit, Processed

Add checkmark on Resubmit

Show error or success message

### Merge Checklist

Please check all of the following items before merging

- [ ] No new WPCS issues
- [ ] No notices, warnings or errors in debug.log
- [ ] No sonar cloud issues
- [ ] No errors while running automated tests
