### PR TITLE
Fixed Missing Next button in single question quiz 

### DIFF
--- a/js/qsm-quiz.js
+++ b/js/qsm-quiz.js
@@ -1049,7 +1049,12 @@ function check_if_show_start_quiz_button(container, total_pages, page_number) {
 		container.find(".mlw_custom_next").hide();
 	}else{
 		container.find(".mlw_custom_start").hide();
-		if(total_pages != parseInt(page_number) + 2){ // check if not last page based on condition (1140)
+		let numberToAdd = 2;
+		// Fixed Missing Next Button in single question quiz created with text after quiz
+		if ( '3' == total_pages && 0 < jQuery('.quiz_end .mlw_qmn_message_end').length ) {
+			numberToAdd = 1;
+		}
+		if(total_pages != parseInt(page_number) + numberToAdd){ // check if not last page based on condition (1140)
 			container.find(".mlw_custom_next").show();
 			if (jQuery('.quiz_end').is(':visible')) {
 				container.find(".mlw_custom_next").hide();

--- a/readme.txt
+++ b/readme.txt
@@ -166,6 +166,7 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 = 9.0.3 ( Beta ) =
 * Bug: Fixed QSM block first question title save
 * Bug: Fixed QSM block answer option inserter button
+* Bug: Fixed Missing Next button in single question quiz created with text after quiz
 
 = 9.0.2 ( June 05, 2024 ) =
 * Bug: Fixed security vulnerability


### PR DESCRIPTION
Fixed Missing Next button in single question quiz created with text after quiz
### Merge Checklist

Please check all of the following items before merging

- [ ] No new WPCS issues
- [ ] No notices, warnings or errors in debug.log
- [ ] No sonar cloud issues
- [ ] No errors while running automated tests
