### PR TITLE
Fixed: wpApiSettings JS error

### DIFF
--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -473,7 +473,8 @@ class MLWQuizMasterNext {
 			}
 		}
 		// load admin JS after all dependencies are loaded
-		wp_enqueue_script( 'qsm_admin_js', plugins_url( 'js/qsm-admin.js', __FILE__ ), array( 'jquery', 'backbone', 'underscore', 'wp-util', 'jquery-ui-sortable', 'jquery-touch-punch', 'qsm-jquery-multiselect-js' ), $this->version, true );
+		/**  Fixed wpApiSettings is not defined js error by using 'wp-api-request' core script to allow the use of localized version of wpApiSettings. **/
+		wp_enqueue_script( 'qsm_admin_js', plugins_url( 'js/qsm-admin.js', __FILE__ ), array( 'jquery', 'backbone', 'underscore', 'wp-util', 'jquery-ui-sortable', 'jquery-touch-punch', 'qsm-jquery-multiselect-js', 'wp-api-request' ), $this->version, true );
 		wp_enqueue_style( 'jquer-multiselect-css', QSM_PLUGIN_CSS_URL . '/jquery.multiselect.min.css', array(), $this->version );
 		wp_enqueue_script( 'qsm-jquery-multiselect-js', QSM_PLUGIN_JS_URL . '/jquery.multiselect.min.js', array( 'jquery' ), $this->version, true );
 		wp_enqueue_script( 'micromodal_script', plugins_url( 'js/micromodal.min.js', __FILE__ ), array( 'jquery', 'qsm_admin_js' ), $this->version, true );

--- a/readme.txt
+++ b/readme.txt
@@ -163,6 +163,10 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 18. Database
 
 == Changelog ==
+= 9.0.5 ( Beta ) =
+* Fixed: quiz contact form email allow domains validation
+* Fixed: wpApiSettings JS error
+
 = 9.0.4 ( June 10, 2024 ) =
 * Enhancement: Improved HTML code management on the result page
 


### PR DESCRIPTION
Uncaught ReferenceError: wpApiSettings is not defined at HTMLAnchorElement. (qsm-admin.js?ver=9.0.4:1138:24) 
### Merge Checklist

Please check all of the following items before merging

- [ ] No new WPCS issues
- [ ] No notices, warnings or errors in debug.log
- [ ] No sonar cloud issues
- [ ] No errors while running automated tests
