### PR TITLE
fixed php warning if quiz_settings are blank

### DIFF
--- a/php/classes/class-qsm-contact-manager.php
+++ b/php/classes/class-qsm-contact-manager.php
@@ -569,7 +569,7 @@ class QSM_Contact_Manager {
 				/**
 				 * Add options validation
 				 */
-				if ( isset( $field['options'] ) && !empty( trim( $field['options'] ) ) ) {
+				if ( isset( $field['options'] ) && ! empty( trim( $field['options'] ) ) ) {
 				?>
 				<span class='mlw_qmn_question qsm_question'><?php echo esc_attr( $field_label ); ?></span>
 				<div class='qmn_radio_answers <?php echo esc_attr( $class ); ?>'>
@@ -603,7 +603,7 @@ class QSM_Contact_Manager {
 					$fieldAttr .= " autocomplete='off' ";
 				}
 				// If REQUIRED is set then assigning the required class
-				if ( isset( $field['options'] ) && !empty( trim( $field['options'] ) ) ) {
+				if ( isset( $field['options'] ) && ! empty( trim( $field['options'] ) ) ) {
 				?>
 				<span class='mlw_qmn_question qsm_question'><label for="contact_field_<?php echo esc_attr( $index ) ?>"><?php echo esc_attr( $field_label ); ?></label></span>
 				<select class='<?php echo esc_attr( $class ); ?>' name='contact_field_<?php echo esc_attr( $index ); ?>' id='contact_field_<?php echo esc_attr( $index ); ?>'>

--- a/php/classes/class-qsm-install.php
+++ b/php/classes/class-qsm-install.php
@@ -2029,7 +2029,9 @@ class QSM_Install {
 			if ( ! get_option( 'fixed_duplicate_questions' ) ) {
 				QSM_Migrate::fix_duplicate_questions();
 			}
-			QSM_Migrate::fix_deleted_quiz_posts();
+			if ( ! get_option( 'fix_deleted_quiz_posts' ) ) {
+				QSM_Migrate::fix_deleted_quiz_posts();
+			}
 
 			update_option( 'mlw_quiz_master_version', $data );
 		}

--- a/php/classes/class-qsm-migrate.php
+++ b/php/classes/class-qsm-migrate.php
@@ -123,7 +123,7 @@ class QSM_Migrate {
 		if ( ! empty( $all_quizzes ) ) {
 			foreach ( $all_quizzes as $quiz ) {
 				$quiz_id     = $quiz->quiz_id;
-				$settings    = maybe_unserialize( $quiz->quiz_settings );
+				$settings    = ! empty( $quiz->quiz_settings ) ? maybe_unserialize( $quiz->quiz_settings ) : array();
 				$pages       = isset( $settings['pages'] ) ? maybe_unserialize( $settings['pages'] ) : array();
 				$qpages      = isset( $settings['qpages'] ) ? maybe_unserialize( $settings['qpages'] ) : array();
 				if ( ! empty( $pages ) ) {
@@ -179,6 +179,7 @@ class QSM_Migrate {
 				}
 			}
 		}
+		update_option( 'fix_deleted_quiz_posts', 1 );
 	}
 
 }


### PR DESCRIPTION
### Merge Checklist

Please check all of the following items before merging

- [x] No new WPCS issues
- [x] No notices, warnings or errors in debug.log
- [x] No sonar cloud issues
- [x] No errors while running automated tests
