### PR TITLE
Fix hardcoded quiz_id in delete_quiz() causing wrong questions to be unlinked

### DIFF
--- a/php/classes/class-qmn-quiz-creator.php
+++ b/php/classes/class-qmn-quiz-creator.php
@@ -323,7 +323,7 @@ class QMNQuizCreator {
 		}
 
 		if ( $qsm_delete ) {
-			$question_results = $wpdb->get_results( "SELECT `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `quiz_id` = 60" );
+			$question_results = $wpdb->get_results( $wpdb->prepare( "SELECT `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `quiz_id` = %d", $quiz_id ) );
 			// Loop through each result and unlink question by its ID
 			foreach ( $question_results as $result ) {
 				$question_id = $result->question_id;


### PR DESCRIPTION
## Summary

- `QMNQuizCreator::delete_quiz()` had a hardcoded `quiz_id = 60` instead of using the `$quiz_id` parameter passed to the function
- Every quiz deletion was unlinking questions from quiz 60 rather than the quiz actually being deleted
- Also wraps the query in `$wpdb->prepare()` for proper SQL parameterization

## Bug Details

**File:** `php/classes/class-qmn-quiz-creator.php`, line 326

**Before:**
```php
$question_results = $wpdb->get_results( "SELECT `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `quiz_id` = 60" );
```

**After:**
```php
$question_results = $wpdb->get_results( $wpdb->prepare( "SELECT `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `quiz_id` = %d", $quiz_id ) );
```

## Impact

This bug affects **every quiz deletion**. When a user deletes any quiz:
1. Questions from quiz ID 60 are incorrectly unlinked (data corruption)
2. Questions from the actually-deleted quiz are **not** unlinked (orphaned data)

## Test plan

- [ ] Delete a quiz and verify its questions are properly unlinked
- [ ] Verify questions from other quizzes (especially quiz 60 if it exists) are not affected
- [ ] Test with "delete questions from question bank" option enabled and disabled