### PR TITLE
Fix IDOR in block editor REST routes — enforce per-quiz ownership

### DIFF
--- a/blocks/block.php
+++ b/blocks/block.php
@@ -329,8 +329,14 @@ if ( ! class_exists( 'QSMBlock' ) ) {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'qsm_quiz_structure_data' ),
-					'permission_callback' => function () {
-						return current_user_can( 'edit_qsm_quizzes' );
+					'permission_callback' => function ( WP_REST_Request $request ) {
+						if ( ! current_user_can( 'edit_qsm_quizzes' ) ) {
+							return false;
+						}
+						$quiz_id = isset( $request['quizID'] ) ? intval( $request['quizID'] ) : 0;
+						return function_exists( 'qsm_current_user_can_edit_quiz' )
+							? qsm_current_user_can_edit_quiz( $quiz_id )
+							: false;
 					},
 				)
 			);
@@ -435,6 +441,13 @@ if ( ! class_exists( 'QSMBlock' ) ) {
 
 			if ( empty( $quiz_id ) && ! is_numeric( $quiz_id ) ) {
 				$result['msg'] = __( 'Invalid quiz id', 'quiz-master-next' );
+				return $result;
+			}
+
+			// Defense-in-depth: refuse to leak quiz structure or a usable rest_nonce
+			// for a quiz the current user is not authorized to edit.
+			if ( function_exists( 'qsm_current_user_can_edit_quiz' ) && ! qsm_current_user_can_edit_quiz( $quiz_id ) ) {
+				$result['msg'] = __( 'Unauthorized!', 'quiz-master-next' );
 				return $result;
 			}
 
@@ -601,6 +614,16 @@ if ( ! class_exists( 'QSMBlock' ) ) {
 					'status' => 'error',
 					'msg'    => __( 'Missing quiz_id or post_id', 'quiz-master-next' ),
 					'post'   => $_POST,
+				);
+			}
+
+			// Enforce per-quiz ownership: the route's permission_callback only checks
+			// the broad edit_qsm_quizzes cap, so a contributor could otherwise rename
+			// or publish a quiz they do not own by passing its id in the request body.
+			if ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) || ! qsm_current_user_can_edit_quiz( $quiz_id ) ) {
+				return array(
+					'status' => 'error',
+					'msg'    => __( 'Unauthorized!', 'quiz-master-next' ),
 				);
 			}
 

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -464,6 +464,12 @@ function qsm_rest_save_emails( WP_REST_Request $request ) {
 	// Makes sure user is logged in.
 	if ( is_user_logged_in() ) {
 		$current_user = wp_get_current_user();
+		if ( ! qsm_current_user_can_edit_quiz( $request['id'] ) ) {
+			return array(
+				'status' => 'error',
+				'msg'    => __( 'Unauthorized!', 'quiz-master-next' ),
+			);
+		}
 		$stop         = qsm_verify_rest_user_nonce( $request['id'], $current_user->ID, $request['rest_nonce'] );
 		if ( ! $stop ) {
 			if ( ! isset( $request['emails'] ) || ! is_array( $request['emails'] ) ) {


### PR DESCRIPTION
Adds qsm_current_user_can_edit_quiz checks to:
- /quiz/structure permission_callback and handler, so contributors can no longer leak quiz structure or a rest_nonce bound to a quiz they do not own.
- /quiz/save_quiz handler, so contributors cannot rename or publish quizzes they do not own via the request body.
- qsm_rest_save_emails callback, matching the in-callback ownership gate already present in qsm_rest_save_results and qsm_rest_save_question.

### Merge Checklist

Please check all of the following items before merging

- [ ] No new WPCS issues
- [ ] No notices, warnings or errors in debug.log
- [ ] No sonar cloud issues
- [ ] No errors while running automated tests
