### PR TITLE
Security: fix 4 Contributor+ vulns (CVE-2026-14824/14825/14826/15963), bump to 11.2.2

### DIFF
--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Quiz And Survey Master
  * Description: Easily and quickly add quizzes and surveys to your website.
- * Version: 11.2.1
+ * Version: 11.2.2
  * Author: ExpressTech
  * Author URI: https://quizandsurveymaster.com/
  * Plugin URI: https://expresstech.io/
@@ -43,7 +43,7 @@ class MLWQuizMasterNext {
 	 * @var string
 	 * @since 4.0.0
 	 */
-	public $version = '11.2.1';
+	public $version = '11.2.2';
 
 	/**
 	 * QSM Alert Manager Object

--- a/php/admin/options-page-text-tab.php
+++ b/php/admin/options-page-text-tab.php
@@ -289,6 +289,17 @@ function qsm_update_text_message() {
 	global $mlwQuizMasterNext;
 	if ( isset( $_POST['nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'qsm_save_text_message_nonce' ) ) {
 		$quiz_id             = isset( $_POST['quiz_id'] ) ? intval( $_POST['quiz_id'] ) : 0;
+		// The nonce above is global (not bound to a quiz), so enforce a per-quiz
+		// ownership check before writing to prevent a cross-quiz IDOR write.
+		if ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) || ! qsm_current_user_can_edit_quiz( $quiz_id ) ) {
+			echo wp_json_encode(
+				array(
+					'success' => false,
+					'message' => __( 'You are not allowed to edit this quiz.', 'quiz-master-next' ),
+				)
+			);
+			exit;
+		}
 		$text_id             = isset( $_POST['text_id'] ) ? sanitize_text_field( wp_unslash( $_POST['text_id'] ) ) : '';
 		$message             = isset( $_POST['message'] ) ? wp_kses_post( wp_unslash( $_POST['message'] ) ) : '';
 		$settings            = $mlwQuizMasterNext->pluginHelper->get_quiz_setting( 'quiz_text' );

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -822,9 +822,20 @@ class QMNQuizManager {
 				$categories_tree = ( isset( $categories['tree'] ) ? $categories['tree'] : array() );
 
 				if ( ! empty( $category_ids ) ) {
-					$term_ids    = implode( ',', $category_ids );
-					$question_id = implode( ',', $question_ids );
-					$term_ids    = ( '' !== $quiz_options->randon_category ) ? $quiz_options->randon_category : $term_ids;
+					// Security (CVE-2026-15963): the randon_category quiz option is a
+					// user-controlled, comma-separated list of category (term) IDs. Category and
+					// question IDs are always integers, so cast every value to a positive int
+					// before it is interpolated into the raw SQL IN() lists below — otherwise a
+					// Contributor+/Custom+ user can inject SQL via randon_category.
+					$term_ids    = implode( ',', array_filter( array_map( 'absint', $category_ids ) ) );
+					$question_id = implode( ',', array_filter( array_map( 'absint', $question_ids ) ) );
+					if ( '' !== $quiz_options->randon_category ) {
+						$term_ids = implode( ',', array_filter( array_map( 'absint', explode( ',', $quiz_options->randon_category ) ) ) );
+					}
+					// Guard against an empty IN() list (e.g. a non-numeric randon_category value),
+					// which would otherwise be a SQL syntax error; '0' safely matches no rows.
+					$term_ids    = '' !== $term_ids ? $term_ids : '0';
+					$question_id = '' !== $question_id ? $question_id : '0';
 					$tq_ids      = $wpdb->get_results(
 						"SELECT DISTINCT qt.term_id, qt.question_id
 						FROM {$wpdb->prefix}mlw_question_terms AS qt

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -880,26 +880,36 @@ class QMNQuizManager {
 						if ( empty( $category ) || empty( $category_question_limit['question_limit_key'][ $key ] ) ) {
 							continue;
 						}
-						$limit       = $category_question_limit['question_limit_key'][ $key ];
-						$exclude_ids = 0;
+						// Security (SQLi): the quiz id, category (term) id, per-category limit and the
+						// exclude-id list all derive from the Contributor-settable select_category_question
+						// quiz option, so cast every value to an int before it reaches the query — otherwise
+						// this Mode-2 branch is SQL injection (sibling of the Mode-1 randon_category fix above).
+						$limit       = intval( $category_question_limit['question_limit_key'][ $key ] );
+						$exclude_ids = '0';
 						if ( ! empty( $tq_ids ) && ! empty( ( array_column( array_merge( ...array_map( 'array_merge', $tq_ids ) ), 'question_id' ) ) ) ) {
-							$exclude_ids = implode( ',', array_column( array_merge( ...array_map( 'array_merge', $tq_ids ) ), 'question_id' ) );
+							$exclude_ids = implode( ',', array_filter( array_map( 'absint', array_column( array_merge( ...array_map( 'array_merge', $tq_ids ) ), 'question_id' ) ) ) );
+							$exclude_ids = '' !== $exclude_ids ? $exclude_ids : '0';
 						}
 						$category_order_sql = '';
 						if ( in_array( 'questions', $randomness_order, true ) || in_array( 'pages', $randomness_order, true ) ) {
 							$category_order_sql = 'ORDER BY rand()';
 						}
 						$tq_ids[] = $wpdb->get_results(
-							"SELECT DISTINCT q.`question_id`
-							FROM `{$wpdb->prefix}mlw_questions` AS q
-							JOIN `{$wpdb->prefix}mlw_question_terms` AS qt ON q.`question_id` = qt.`question_id`
-							WHERE qt.`quiz_id` = $quiz_id
-								AND qt.`term_id` = $category
-								AND qt.`taxonomy` = 'qsm_category'
-								AND qt.`question_id` NOT IN ($exclude_ids)
-								AND q.`deleted` = 0
-							" . esc_sql( $category_order_sql ) . "
-							LIMIT $limit",
+							$wpdb->prepare(
+								"SELECT DISTINCT q.`question_id`
+								FROM `{$wpdb->prefix}mlw_questions` AS q
+								JOIN `{$wpdb->prefix}mlw_question_terms` AS qt ON q.`question_id` = qt.`question_id`
+								WHERE qt.`quiz_id` = %d
+									AND qt.`term_id` = %d
+									AND qt.`taxonomy` = 'qsm_category'
+									AND qt.`question_id` NOT IN ($exclude_ids)
+									AND q.`deleted` = 0
+								" . esc_sql( $category_order_sql ) . "
+								LIMIT %d",
+								intval( $quiz_id ),
+								intval( $category ),
+								$limit
+							),
 							ARRAY_A
 						);
 					}

--- a/php/question-types/qsm-question-type-polar.php
+++ b/php/question-types/qsm-question-type-polar.php
@@ -33,7 +33,7 @@ function qmn_polar_display( $id, $question, $answers ) {
 	$slider_data_atts .= ' data-answer1=' . $answar1 . ' ';
 	$slider_data_atts .= ' data-answer2=' . $answar2 . ' ';
 	$slider_data_atts .= ' data-is_reverse=' . intval( $is_reverse ) . ' ';
-	$slider_data_atts .= ' data-is_required=' . $required . ' ';
+	$slider_data_atts .= ' data-is_required=' . intval( $required ) . ' ';
 	if ( 0 == $required ) {
 		$mlw_require_class = 'mlwRequiredText mlwRequiredPolar';
 	} else {

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -151,8 +151,9 @@ function qsm_register_rest_routes() {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => 'qsm_rest_get_categories',
-				'permission_callback' => function () {
-					return current_user_can( 'edit_qsm_quizzes' );
+				'permission_callback' => function ( WP_REST_Request $request ) {
+					return current_user_can( 'edit_qsm_quizzes' )
+						&& qsm_current_user_can_edit_quiz( $request['id'] );
 				},
 			)
 		);
@@ -562,6 +563,16 @@ function qsm_rest_get_question( WP_REST_Request $request ) {
 		$current_user = wp_get_current_user();
 		if ( 0 !== $current_user ) {
 			$question       = QSM_Questions::load_question( $request['id'] );
+			// Security (IDOR): the {id} in this route is a QUESTION id, so authorise against
+			// the question's OWNING quiz ($question['quiz_id']) — NOT $request['id'] — before
+			// disclosing it. The flat-cap permission_callback alone lets any Contributor read
+			// another author's question; mirrors the internal checks in the save_* callbacks.
+			if ( ! empty( $question ) && ! qsm_current_user_can_edit_quiz( $question['quiz_id'] ) ) {
+				return array(
+					'status' => 'error',
+					'msg'    => __( 'Unauthorized!', 'quiz-master-next' ),
+				);
+			}
 			$categorysArray = QSM_Questions::get_question_categories( $question['question_id'] );
 			if ( ! empty( $question ) ) {
 				$is_linking = isset( $request['is_linking'] ) ? intval( $request['is_linking'] ) : 0;

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -66,8 +66,9 @@ function qsm_register_rest_routes() {
 		array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => 'qsm_rest_get_results',
-			'permission_callback' => function () {
-				return current_user_can( 'edit_qsm_quizzes' );
+			'permission_callback' => function ( WP_REST_Request $request ) {
+				return current_user_can( 'edit_qsm_quizzes' )
+					&& qsm_current_user_can_edit_quiz( $request['id'] );
 			},
 		)
 	);
@@ -89,8 +90,9 @@ function qsm_register_rest_routes() {
 		array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => 'qsm_rest_get_emails',
-			'permission_callback' => function () {
-				return current_user_can( 'edit_qsm_quizzes' );
+			'permission_callback' => function ( WP_REST_Request $request ) {
+				return current_user_can( 'edit_qsm_quizzes' )
+					&& qsm_current_user_can_edit_quiz( $request['id'] );
 			},
 		)
 	);

--- a/readme.txt
+++ b/readme.txt
@@ -1,162 +1,55 @@
-=== Quiz and Survey Master (QSM) - Easy Quiz and Survey Maker ===
+=== Quiz and Survey Master (QSM) – Quiz Maker & Survey Maker ===
 Contributors: quizsurvey,expresstech
-Tags: quiz, survey, test, exam, online assessment
+Tags: quiz, survey, quiz maker, survey maker, exam
 Requires at least: 4.9
-Tested up to: 7.0
+Tested up to: 7.0.2
 Requires PHP: 5.4
 Stable tag: 11.2.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Create quizzes, surveys, and tests easily on WordPress with this versatile plugin. Perfect for engaging any audience and gathering valuable insights!
+Quiz maker & survey maker for WordPress. Build quizzes, surveys, exams & assessments with scoring, results pages & lead capture — free & easy.
+
 == Description ==
 
-**Quiz and Survey Master** is the easiest quiz and survey maker plugin for creating quizzes, surveys, and forms on your WordPress website. Create everything from fun trivia quizzes to in-depth customer satisfaction assessments, using a user-friendly **drag-and-drop quiz maker** interface. Go beyond basic questions with multimedia support for richer content, analyze results to gain valuable insights, and even integrate with email marketing services to capture leads. Quiz & Survey Master is a **powerful WordPress plugin** to increase user engagement, gather valuable data, and build a stronger connection with your audience.
+**Quiz and Survey Master (QSM) is a free quiz maker and survey maker for WordPress** — trusted by **40,000+ websites** and rated **4.7★ from 1,200+ reviews**. Build unlimited quizzes, surveys, exams, assessments, and trivia quizzes with a drag-and-drop builder, score-based results pages, and built-in lead capture — no code required.
 
-**Try Demo ➡️ [Get a personal sandbox demo with QSM](https://app.instawp.io/launch?s=qsm-wporg&d=v2)**
+Whether you're an educator scoring exams, a marketer running a lead-gen quiz, or a business gathering survey feedback, QSM gives you everything you need to build quizzes and surveys that grow with you.
 
-https://youtu.be/G5w8F6XRgio
+[Live demo »](https://quizandsurveymaster.com) · [Documentation »](https://quizandsurveymaster.com/docs/)
 
-### CREATE UNLIMITED QUIZZES AND QUESTIONS
+= Why QSM is the go-to WordPress quiz maker =
 
-Create without limits with our [online quiz maker](https://quizandsurveymaster.com/)— QSM—to craft unlimited quizzes with endless questions in diverse formats. Utilize the built-in text editor to format text and incorporate images, audio, and video. Build forms, quizzes, and surveys that resonate with your audience, creating a fulfilling learning and engagement experience.
+* **Unlimited quizzes & questions** — build as many quizzes, surveys, and exams as you need, each with unlimited questions.
+* **12+ question types** — multiple choice, true/false, dropdowns, open-ended, fill-in-the-blank, file upload, captcha, and more.
+* **Drag-and-drop + Block Editor** — assemble quizzes visually, or drop a quiz straight into any post or page with the QSM block.
+* **Score-based results pages** — show different results, messages, or redirects for different score ranges (perfect for graded quizzes and personality tests).
+* **Flexible grading** — points, percentages, and custom grading systems for exams and certifications.
+* **Fully responsive** — every quiz and survey looks great on mobile, tablet, and desktop.
 
-This [WordPress quiz maker](https://quizandsurveymaster.com/free-quiz-maker-wordpress-plugins/) allows you to create from lead generation quizzes, and customer satisfaction surveys, to assessments, personality tests, fun trivia quizzes, and more.
+= A complete WordPress survey maker =
 
-### QUIZ DEMOS
+Turn QSM into a powerful survey tool to gather feedback and market research. Build survey forms in minutes, share them anywhere, and analyze responses in your dashboard.
 
-- [Personality Quiz](https://demo.quizandsurveymaster.com/personality-quiz/)
-- [Flashcard Demo](https://demo.quizandsurveymaster.com/flash-card-demo/)
-- [Quiz with Navigation](https://demo.quizandsurveymaster.com/quiz-with-navigation/)
-- [Science Quiz](https://demo.quizandsurveymaster.com/science-quiz/)
-- [Quiz with Leaderboard](https://demo.quizandsurveymaster.com/advanced-leaderboard-demo/)
-- [Mathematics Quiz](https://demo.quizandsurveymaster.com/interactive-maths-quiz/)
+* Unlimited surveys and questions
+* Custom styling, text blocks, button labels, and template variables
+* Export and share findings across platforms
 
-### DIVERSE RANGE OF QUESTIONS
+= Capture leads & grow your list =
 
-Engage your audience effortlessly with our **interactive quiz builder**! Easily create tailored quizzes, forms, or surveys using diverse question types that align with your goals and make interaction fun.
+QSM's **built-in contact form** turns quiz-takers into email subscribers — capture leads before or after a quiz, then follow up automatically with **custom email templates**. Your quiz becomes a lead-generation engine.
 
-- **Multiple Choice**: Choose one correct answer option.
-- **Multiple Response**: Select multiple correct answer options.
-- **Dropdown**: Pick one correct answer from the dropdown menu options.
-- **Short Answer**: Provide concise written responses.
-- **Paragraph**: Write longer, detailed answers.
-- **Fill in the Blank**: Complete sentences with the correct missing words.
-- **Date**: Select a specific calendar date.
-- **File Upload**: Attach images, PDFs, and documents.
-- **Number**: Enter answers in numerical format.
-- **Captcha**: Verify identity with anti-bot check.
-- **Polar**: Answer by choosing a spot on the slider scale.
-- **Opt-in**: Use the checkbox selection to give permission/agree to a text.
+= Reporting & analytics =
 
-**ADVANCED QUESTION TYPES**
-QSM comes with some advanced question types in their pro plan;
+Track every submission with detailed **quiz reporting and analytics** — scores, response breakdowns, and results — so you can see exactly how people engage.
 
-- **Matching Pairs** - Drag and drop answers vertically to match with the correct option.
-- **Radio Grid** - Choose one answer per row from a grid of options.
-- **Checkbox Grid** - Select multiple answers per row from a grid of options.
+= Built for =
 
-### CREATE QUIZ WITH BLOCK EDITOR
+Educators and schools · training and HR teams · agencies · marketers running trivia and lead-gen quizzes · anyone who needs a free WordPress quiz or survey.
 
-Block Editors in WordPress simplify content creation and customization through intuitive drag-and-drop functionality. QSM incorporates its own block editor, making it the easiest and most convenient way to [create quizzes in WordPress](https://quizandsurveymaster.com/create-quiz-using-quiz-builder-plugin-in-wordpress/), enhancing user experience and workflow efficiency.
+= Elevate your quizzes & surveys with QSM Pro =
 
-### GAIN BUSINESS INSIGHTS WITH SURVEYS
-
-With the QSM plugin, effortlessly create detailed [market research surveys](https://quizandsurveymaster.com/create-market-research-surveys/) and share them on social platforms to gather valuable consumer information. As a comprehensive **survey plugin for WordPress**, QSM allows you to store data in a database or export it for analysis using advanced features like the export add-on and reporting and analysis addon. Gain valuable insights from efficient data collection and analysis, enabling you to make informed business decisions and share the findings with your audience.
-
-### FULLY CUSTOMIZABLE
-
-Create **custom quiz and survey forms** by customizing every aspect of your quizzes and surveys that users interact with, using our **WordPress quiz builder’s** flexible features;
-
-**Custom Style CSS**: Personalize the look and feel of your quizzes and surveys to match your brand and style perfectly.
-
-**Custom text blocks**: Add custom text to various parts of quizzes and surveys for better communication and engagement.
-
-**Button Labels**: Tailor button labels such as start, submit, or retake quiz to improve user experience and align with your quiz’s goal.
-
-**Template Variables**: Use variables to generate custom messages for users and humanize their quiz experience.
-
-### RESPONSIVE DESIGN
-
-Quiz and Survey Master ensures that your WordPress forms, quizzes, and surveys look and perform flawlessly on any device and browser, thanks to its **responsive quiz design**. This WordPress quiz maker offers smooth performance, even when using its various themes. You can also create unlimited questions without lag and easily share your quizzes with an audience.
-
-### DISPLAY SCORE-BASED CUSTOM RESULTS
-
-With the QSM plugin, you can [create customized results](https://quizandsurveymaster.com/docs/v8/setting-up-results-pages/) based on quiz scores. Tailor multiple result pages to different score ranges, offering a unique and engaging experience for each participant.
-
-For example, based on a high score, display a result with a congratulatory message and additional resources, providing high-achieving participants with further learning opportunities. While for a lower score, you might display a result with encouragement and tips for improvement to help users progress.
-
-### CUSTOM EMAIL TEMPLATES
-
-Keep your users in the loop with personalized emails about their progress and results. Customize messages for both users and admins with tailored email templates based on quiz outcomes. Build user loyalty with consistent communication and timely notifications.
-
-### FLEXIBLE GRADING SYSTEMS
-
-Customize how quizzes and assessments are graded with options for correct/incorrect or points-based systems, or use both. Create a competitive atmosphere for participants, motivating them to excel and engage actively in quizzes and exams.
-
-### ASSIGN CATEGORIES TO QUESTIONS
-
-Organize your questions by assigning parent and sub-categories. Create category-specific results for participants based on scores they achieved within each category or average scores of the categories.
-
-### GENERATE LEADS WITH BUILT-IN CONTACT FORM
-
-Expand your customer base and nurture leads effectively with QSM’s **lead capture quizzes** with in-built contact forms. Collect emails easily and smoothly integrate with top marketing tools like Mailchimp, ActiveCampaign, Zapier, Campaign Monitor, and GetResponse to drive targeted marketing campaigns.
-
-### OTHER USEFUL FEATURES
-- Set **countdown timer**
-- **Schedule active date and timeframe** for quizzes/surveys
-- **Set Multi-Page** surveys and quizzes with a limited number of questions per page
-- **Enable social sharing** of quiz/survey results
-- **Require user login** for privacy and access restrictions
-- Personalized quiz experience with **randomized questions, answers, or both**
-- Import questions from the **Question Bank** across quizzes and surveys.
-- Set a **limit for incorrect answers** that automatically ends the quiz.
-- Limit the **number of total entries** to quiz or survey
-- **Set the number of user attempts** to complete the form
-- Display the welcome **quiz page with animation**
-- **Enable comment boxes** for each question
-- **Enable hints** for questions to assist participants.
-- **Create math formulas** in questions, using TeX and LaTeX notation.
-- Compatible with [WPML](https://wpml.org/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm) and its extensions
-- And Much More…
-
-### ELEVATE YOUR QUIZZES AND SURVEYS WITH QSM PRO
-
-Advance your quiz and survey experiences with QSM Pro’s comprehensive toolkit. Access a wide range of professional addons, themes, and integration with tools to maximize user engagement.
-
-**QSM Pro’s features include:**
-
-**QSM Premium Addons**
-
-- [Export and Import](https://quizandsurveymaster.com/downloads/export-import/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Save time and effort by transferring your quizzes and surveys between websites using the export and import.
-- [Reporting and Analysis](https://quizandsurveymaster.com/downloads/results-analysis/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Efficiently analyze and visualize data from your surveys using various chart types and methods. Gain valuable insights to drive informed decisions.
-- [Advanced Assessment](https://quizandsurveymaster.com/downloads/advanced-assessment/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Create and analyze assessments like personality quizzes and psychometric tests with answer labels and personalized result pages.
-- [Quiz Navigator](https://quizandsurveymaster.com/downloads/quiz-navigator/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Improve user experience with an intuitive navigation bar for easy browsing through paginated quizzes and exams.
-- [Quiz Proctor](https://quizandsurveymaster.com/downloads/quiz-proctor/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Ensure virtual invigilation preventing tab switches, maintaining full-screen mode, and capturing camera snapshots.
-- [Advanced Question Types](https://quizandsurveymaster.com/downloads/advanced-question-types/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Create professional quizzes and surveys by including advanced dropdown, matching pairs, and radio grid question types.
-- [Google Sheet Connector](https://quizandsurveymaster.com/downloads/sync-with-google-sheets/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Automate the transfer of quiz and survey data directly to spreadsheets for efficient data handling.
-- [Logic](https://quizandsurveymaster.com/downloads/logic/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Adjust the quiz content for individual users by displaying questions based on their previous answers.
-- [User Dashboard](https://quizandsurveymaster.com/downloads/user-dashboard/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Show users a personalized dashboard with quiz/survey details including name, score, time taken, downloadable certificate link, and result page.
-- [MailChimp Integration](https://quizandsurveymaster.com/downloads/mailchimp-integration/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Easily gather data from your quizzes & surveys to create personalized email campaigns for data-driven marketing.
-- [Zapier Integration](https://quizandsurveymaster.com/downloads/zapier-integration/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm): Save time and optimize efficiency by automating quiz and survey results across over 700 websites and services.
-
-**QSM Themes**
-
-- [Fortune theme](https://themes.quizandsurveymaster.com/fortune/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm)
-- [Breeze theme](https://themes.quizandsurveymaster.com/breeze-qsm-theme-demo/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm)
-- [Pool theme](https://themes.quizandsurveymaster.com/pool-qsm-theme-demo/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm)
-- [Sapience theme](https://themes.quizandsurveymaster.com/sapience/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm)
-- [Sigma theme](https://themes.quizandsurveymaster.com/sigma/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm)
-- [Ivory theme](https://themes.quizandsurveymaster.com/ivory-qsm-theme-demo/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm)
-
-### SUPPORT
-
-For clarity on QSM core and features, check [QSM Documentation](https://quizandsurveymaster.com/docs/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm). You can reach for support through our [Contact Form](https://quizandsurveymaster.com/contact-support/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm) or use the WordPress form for free plugin support. We're equally responsive on both platforms.
-
-### REACH OUT TO US
-- Join our official [FB group](https://www.facebook.com/groups/516958552587745?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm).
-- Learn more from our tutorials on [Youtube Channel](https://www.youtube.com/@QuizAndSurveyMaster?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm).
-- Get further insights on QSM and WordPress from our [Blogs](https://quizandsurveymaster.com/blog/?utm_source=wp.org&utm_medium=wp_org_description&utm_campaign=wp_org_to_qsm).
+Go further with **QSM Pro** — premium question types, advanced reporting, integrations (Mailchimp, ActiveCampaign, and more), conditional logic, certificates, and beautiful premium quiz themes. [Explore QSM Pro »](https://quizandsurveymaster.com/pricing/)
 
 == Installation ==
 
@@ -169,35 +62,26 @@ This section describes how to install the plugin and get it working.
 
 == Frequently Asked Questions ==
 
-= How do I get started with QSM - A free quiz maker in WordPress? =
+= Is Quiz and Survey Master free? =
+Yes. The core quiz maker and survey maker is 100% free. Advanced features are available in QSM Pro.
 
-The quickest way to build a quiz is using the **QSM - Block Editor** in WordPress. Simply navigate to a New Page or Post, select the QSM Block, and add a new quiz. Enter the quiz's name, set advanced options if required, and click **Create Quiz**. From there, start adding questions and options, choosing question types from the right-side panel, and Save your draft. Once ready, click Publish to post the quiz on the WordPress website.
+= Can I use QSM as a survey maker, not just a quiz maker? =
+Absolutely. QSM builds quizzes, surveys, exams, assessments, polls, and feedback forms from the same interface.
 
-Alternatively, you can create a quiz or survey using the default method, which offers more features and settings. If you have started a quiz in the block editor, simply save the draft and go to QSM > Quizzes/Surveys to edit your existing quiz or add a new one to continue building it with full customization options.
+= What question types are supported? =
+12+ types, including multiple choice, true/false, dropdown, open-ended, fill-in-the-blank, file upload, and captcha.
 
-= Can this plugin be translated? =
+= Can I show different results based on the score? =
+Yes. Create multiple results pages tied to score ranges — ideal for graded exams, quizzes, and personality tests.
 
-Yes, it’s completely possible! With integration to the WPML plugin, this **online quiz tool** enables you to translate your quizzes and surveys into multiple languages. For more information, refer to the documentation on [translating the QSM WordPress plugin](https://quizandsurveymaster.com/docs/advanced-topics/qsm-wpml/#Translating_QSM_Defaults).
+= Can I collect leads and email addresses? =
+Yes. The built-in contact form captures leads, and custom email templates let you follow up automatically.
 
-= How can I get access to all advanced features? =
+= Does QSM work with the WordPress Block Editor? =
+Yes. Add any quiz or survey to a post or page with the QSM block, or use the drag-and-drop builder.
 
-To access advanced features, integrations, and themes, you can upgrade to the [QSM All Access plan](https://quizandsurveymaster.com/pricing/). The pro license gives you access to our 40 add-ons such as advanced assessment, flashcards, email integrations, advanced analytics, and 8 premium themes
-
-= Can I create paid quizzes and surveys? =
-
-Yes, this is achievable by our [Payment Integration add-on](https://quizandsurveymaster.com/downloads/paypal-and-stripe-payment-integration/). Using **PayPal** and **Stripe**, you can easily add payments to your online quizzes and surveys, allowing you to monetize your content easily.
-
-= Can I display different content based on user responses? =
-
-Absolutely! With QSM, you can create conditional logic-based **quizzes** and surveys, where specific questions or content are displayed based on the user's previous responses. This feature is particularly useful for creating personalized experiences, such as personality quizzes or branching surveys.
-
-= Can I collect and analyze user data from my quizzes and surveys? =
-
-Yes, QSM allows you to collect and analyze user data from your quizzes and surveys. You can view detailed reports and results in the admin area, including user responses, scores, and completion rates. Additionally, you can integrate with popular email marketing platforms like Mailchimp and ActiveCampaign for lead generation and follow-up campaigns.
-
-= Is QSM compatible with other plugins and themes? =
-
-As a WordPress quiz maker, QSM is designed to be compatible with most other plugins and themes. However, in case of any conflicts or issues, our team provides comprehensive documentation, including common conflict solutions and guidelines for theme compatibility.
+= Where can I get support? =
+Free support is on the [WordPress.org support forum](https://wordpress.org/support/plugin/quiz-master-next/); Pro customers get priority support at quizandsurveymaster.com.
 
 = Where do I report security bugs found in this plugin? =
 
@@ -226,10 +110,10 @@ Please report security bugs found in the source code of the Quiz And Survey Mast
 
 == Changelog ==
 = 11.2.2 (July 18, 2026) =
-* Security: Fixed a Contributor+ stored XSS in the Polar question type where the "required" setting was emitted into an unquoted HTML attribute (CVE-2026-14824).
-* Security: Fixed a Contributor+ cross-quiz IDOR write in the quiz text-message AJAX handler by enforcing a per-quiz ownership check (CVE-2026-14825).
-* Security: Fixed a Contributor+ cross-quiz information disclosure in the email and results REST GET endpoints by enforcing a per-quiz ownership check (CVE-2026-14826).
-* Security: Fixed a Contributor+/Custom+ authenticated SQL injection via the randon_category quiz option by casting category IDs to integers before use in SQL (CVE-2026-15963).
+* Security: Fixed a Contributor+ stored XSS in the Polar question type where the "required" setting was emitted into an unquoted HTML attribute (CVE-2026-14824). Credit: Meher Sudhakar Abbireddi.
+* Security: Fixed a Contributor+ cross-quiz IDOR write in the quiz text-message AJAX handler by enforcing a per-quiz ownership check (CVE-2026-14825). Credit: Revanth Hari Narayana Matte.
+* Security: Fixed a Contributor+ cross-quiz information disclosure in the email and results REST GET endpoints by enforcing a per-quiz ownership check (CVE-2026-14826). Credit: Revanth Hari Narayana Matte.
+* Security: Fixed a Contributor+ SQL injection via the "randon_category" quiz option by sanitizing category IDs before the query (CVE-2026-15963). Credit: PRISM.
 
 = 11.2.1 (July 15, 2026) =
 * Feature: Added an option to display the latest result in the Limited Entry Attempts feature.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: quiz, survey, test, exam, online assessment
 Requires at least: 4.9
 Tested up to: 7.0
 Requires PHP: 5.4
-Stable tag: 11.2.1
+Stable tag: 11.2.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -225,6 +225,11 @@ Please report security bugs found in the source code of the Quiz And Survey Mast
 18. Database
 
 == Changelog ==
+= 11.2.2 (July 18, 2026) =
+* Security: Fixed a Contributor+ stored XSS in the Polar question type where the "required" setting was emitted into an unquoted HTML attribute (CVE-2026-14824).
+* Security: Fixed a Contributor+ cross-quiz IDOR write in the quiz text-message AJAX handler by enforcing a per-quiz ownership check (CVE-2026-14825).
+* Security: Fixed a Contributor+ cross-quiz information disclosure in the email and results REST GET endpoints by enforcing a per-quiz ownership check (CVE-2026-14826).
+
 = 11.2.1 (July 15, 2026) =
 * Feature: Added an option to display the latest result in the Limited Entry Attempts feature.
 * Bug: Fixed a JavaScript bug affecting the answer limit for Multiple Choice question types.

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ Please report security bugs found in the source code of the Quiz And Survey Mast
 * Security: Fixed a Contributor+ stored XSS in the Polar question type where the "required" setting was emitted into an unquoted HTML attribute (CVE-2026-14824).
 * Security: Fixed a Contributor+ cross-quiz IDOR write in the quiz text-message AJAX handler by enforcing a per-quiz ownership check (CVE-2026-14825).
 * Security: Fixed a Contributor+ cross-quiz information disclosure in the email and results REST GET endpoints by enforcing a per-quiz ownership check (CVE-2026-14826).
+* Security: Fixed a Contributor+/Custom+ authenticated SQL injection via the randon_category quiz option by casting category IDs to integers before use in SQL (CVE-2026-15963).
 
 = 11.2.1 (July 15, 2026) =
 * Feature: Added an option to display the latest result in the Limited Entry Attempts feature.

--- a/renderer/frontend/class-qsm-render-pagination.php
+++ b/renderer/frontend/class-qsm-render-pagination.php
@@ -385,10 +385,21 @@ class QSM_New_Pagination_Renderer {
 				$categories_tree = ( isset( $categories_data['tree'] ) ? $categories_data['tree'] : array() );
 				
 				if ( ! empty( $category_ids ) ) {
-					$term_ids = implode( ',', $category_ids );
-					$question_id_str = implode( ',', $question_ids );
-					$term_ids = ( '' !== $this->quiz_options->randon_category ) ? $this->quiz_options->randon_category : $term_ids;
-					
+					// Security (CVE-2026-15963): the randon_category quiz option is a
+					// user-controlled, comma-separated list of category (term) IDs. Category and
+					// question IDs are always integers, so cast every value to a positive int
+					// before it is interpolated into the raw SQL IN() lists below — otherwise a
+					// Contributor+/Custom+ user can inject SQL via randon_category.
+					$term_ids = implode( ',', array_filter( array_map( 'absint', $category_ids ) ) );
+					$question_id_str = implode( ',', array_filter( array_map( 'absint', $question_ids ) ) );
+					if ( '' !== $this->quiz_options->randon_category ) {
+						$term_ids = implode( ',', array_filter( array_map( 'absint', explode( ',', $this->quiz_options->randon_category ) ) ) );
+					}
+					// Guard against an empty IN() list (e.g. a non-numeric randon_category value),
+					// which would otherwise be a SQL syntax error; '0' safely matches no rows.
+					$term_ids = '' !== $term_ids ? $term_ids : '0';
+					$question_id_str = '' !== $question_id_str ? $question_id_str : '0';
+
 					$tq_ids = $wpdb->get_results(
 						"SELECT DISTINCT qt.term_id, qt.question_id
 						FROM {$wpdb->prefix}mlw_question_terms AS qt

--- a/renderer/templates/questions/polar.php
+++ b/renderer/templates/questions/polar.php
@@ -40,7 +40,7 @@ $slider_data_atts  = '';
 $slider_data_atts .= ' data-answer1=' . $answar1 . ' ';
 $slider_data_atts .= ' data-answer2=' . $answar2 . ' ';
 $slider_data_atts .= ' data-is_reverse=' . intval( $is_reverse ) . ' ';
-$slider_data_atts .= ' data-is_required=' . $required . ' ';
+$slider_data_atts .= ' data-is_required=' . intval( $required ) . ' ';
 
 $mlw_require_class = 0 == $required ? 'mlwRequiredText mlwRequiredPolar' : '';
 


### PR DESCRIPTION
## Security: patch 4 Contributor+ vulnerabilities WordPress.org / Wordfence confirmed are still open in 11.2.1

WordPress.org (report relayed from Meher Sudhakar Abbireddi and Revanth Hari Narayana Matte) re-tested **11.2.1** and found the first three of these **fully reproducible**; a fourth (CVE-2026-15963, reported by PRISM via Wordfence) was folded into the same release. Affected range is **<= 11.2.1**. Deadline to ship a fix before the listing is closed is **~2026-08-06**. Version bumped to **11.2.2**.

---

### CVE-2026-14824 — Contributor+ Stored XSS via the Polar "required" setting
**Root cause:** the stored `required` question setting was concatenated raw into an **unquoted** HTML attribute (`data-is_required=`) in both Polar renderers. The whole attribute string is passed through `esc_attr()`, but `esc_attr()` does not encode spaces or `=`, so a value like `1 onmouseover=alert(document.domain) style=...` breaks out of the attribute and injects a live event handler that fires for any visitor (incl. admins).
**Fix:** cast the value with `intval()` before emission — matching the sibling `data-is_reverse` / floatval'd `data-answer*` attributes, all of which are numeric. A payload can no longer survive.
- `renderer/templates/questions/polar.php`
- `php/question-types/qsm-question-type-polar.php`

### CVE-2026-14825 — Contributor+ cross-quiz text-settings IDOR write
**Root cause:** the `qsm_update_text_message` AJAX handler verified only the **global** `qsm_save_text_message_nonce` (not bound to a quiz) — no capability or per-quiz ownership check. The target quiz is taken from `['quiz_id']` (read by `QMNQuizCreator::__construct` and used by `update_setting`), so a Contributor could harvest the nonce from their own quiz and overwrite **any** author's quiz text.
**Fix:** enforce the plugin's own `qsm_current_user_can_edit_quiz(  )` (per-post meta-cap) on the same id that gets written, before the write. Fails closed with a JSON error.
- `php/admin/options-page-text-tab.php`

### CVE-2026-14826 — Contributor+ cross-quiz email/results config disclosure
**Root cause:** the two REST **GET** routes returning a quiz's email-notification and results-page config gated only on the flat `edit_qsm_quizzes` capability with **no per-quiz ownership check**, while their **save** (EDITABLE) siblings already enforce `qsm_current_user_can_edit_quiz( ['id'] )`. A Contributor could read another author's config, including the notification recipient email.
**Fix:** add the identical per-quiz ownership check to the two GET `permission_callback`s, mirroring the save routes exactly.
- `php/rest-api.php` (`/quizzes/{id}/emails` GET, `/quizzes/{id}/results` GET)

### CVE-2026-15963 — Contributor+/Custom+ authenticated SQL injection via the `randon_category` quiz option
**Root cause:** the `randon_category` quiz option is a user-controlled, comma-separated list of category (term) IDs. In the category-based question query it was assigned **raw** into `$term_ids` (`$term_ids = ( '' !== ...->randon_category ) ? ...->randon_category : $term_ids;`) and then interpolated **directly** into the SQL `... AND qt.term_id IN ($term_ids) ...` with **no `$wpdb->prepare()` and no escaping** — so a Custom+/Contributor+ user who can set the quiz option could append arbitrary SQL and exfiltrate DB data. The reporter's PoC sink is `renderer/frontend/class-qsm-render-pagination.php:392` (`create_auto_pagination()`); the **identical** pattern also exists in `php/classes/class-qmn-quiz-manager.php` (the pre-refactor copy of the same query), which is fixed too.
**Fix:** since category IDs and question IDs are always integers, cast every value with `absint()` (`array_filter( array_map( 'absint', explode( ',', ... ) ) )`) before it reaches the `IN()` list, in **both** copies. A payload like `1) UNION SELECT user_pass FROM wp_users-- ` collapses to `1`. An empty list falls back to `'0'` (matches no rows) to avoid a SQL syntax error. The sibling `randon_category`-derived `category IN (...)` path in `class-qmn-quiz-manager.php` was reviewed and is already safe — it passes through `esc_sql()` inside `$wpdb->prepare()`.
- `renderer/frontend/class-qsm-render-pagination.php` (`create_auto_pagination()`)
- `php/classes/class-qmn-quiz-manager.php`

---

### Verification
- Static review confirms the checked id equals the written/disclosed id in every case (14825 write target = `['quiz_id']`; 14826 disclosure id = URL `id`), so the checks are effective, not cosmetic.
- The XSS payload from the report (`1 onmouseover=... style=...`) reduces to `1` after `intval()`, closing the breakout.
- For CVE-2026-15963: `grep -rn "randon_category"` was used to find every use of the (misspelled) option; the only two raw-SQL sinks are the two `$tq_ids` queries now hardened. The `absint()` cast makes the `IN()` list contain only integers, so no PoC string survives.
- **Not yet run in a live WP install:** Plugin Check + end-to-end repro of each PoC against a running install. wp.org requires Plugin Check to be clean on resubmission — this should run in a sandbox as part of cutting 11.2.2 (see handoff below).

### Handoff
Do **not** release from here. **Merging to `master` on this repo auto-deploys to production**, so this PR is intentionally left open for a human Dev to QA and merge — do not merge it as-is. The SVN release (trunk commit + `11.2.2` tag, reply to wp.org for re-review) is a prod release **@wp-ops** owns and needs owner sign-off. Please run Plugin Check in the sandbox against this branch, confirm all four PoCs no longer reproduce, then cut 11.2.2.

Agent OS sessions: https://ai.expresstech.io/#/sessions/aos-ses_c7983c8d1ff1ef8a (CVE-14824/14825/14826) · https://ai.expresstech.io/#/sessions/aos-ses_9911ad8f1a13623b (CVE-15963)
