### PR TITLE
fix: set SameSite=None; Secure on question order cookie so randomized…

### DIFF
--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -1026,7 +1026,7 @@ class QMNQuizManager {
 				var qsmCookieExpiryQQMOne = new Date();
 				qsmCookieExpiryQQMOne.setTime(qsmCookieExpiryQQMOne.getTime() + (365 * 24 * 60 * 60 * 1000)); // Set cookie for 1 year
 				var qmsExpiresQQMOne = "expires=" + qsmCookieExpiryQQMOne.toUTCString();
-				document.cookie = "question_ids_<?php echo esc_js( $quiz_id ); ?>=" + "<?php echo esc_js( $question_sql ); ?>" + "; " + qmsExpiresQQMOne + "; path=/";
+				document.cookie = "question_ids_<?php echo esc_js( $quiz_id ); ?>=" + "<?php echo esc_js( $question_sql ); ?>" + "; " + qmsExpiresQQMOne + "; path=/<?php echo is_ssl() ? '; SameSite=None; Secure' : ''; ?>";
 			</script>
 			<?php
 		}
@@ -1293,7 +1293,7 @@ class QMNQuizManager {
 				var qsmCookieExpiryQQMTwo = new Date();
 				qsmCookieExpiryQQMTwo.setTime(qsmCookieExpiryQQMTwo.getTime() + (365*24*60*60*1000));
 				var qmsExpiresQQMTwo = "expires="+ qsmCookieExpiryQQMTwo.toUTCString();
-				document.cookie = "question_ids_<?php echo esc_attr( $options->quiz_id ); ?> = <?php echo esc_attr( $question_list_str ); ?>; "+qmsExpiresQQMTwo+"; path=/";
+				document.cookie = "question_ids_<?php echo esc_attr( $options->quiz_id ); ?> = <?php echo esc_attr( $question_list_str ); ?>; "+qmsExpiresQQMTwo+"; path=/<?php echo is_ssl() ? '; SameSite=None; Secure' : ''; ?>";
 			</script>
 			<?php
 		}

--- a/renderer/frontend/class-qsm-render-pagination.php
+++ b/renderer/frontend/class-qsm-render-pagination.php
@@ -537,7 +537,7 @@ class QSM_New_Pagination_Renderer {
 				var qsmCookieExpiryQRPOne = new Date();
 				qsmCookieExpiryQRPOne.setTime(qsmCookieExpiryQRPOne.getTime() + (365 * 24 * 60 * 60 * 1000)); // Set cookie for 1 year
 				var qmsExpiresQRPOne = "expires=" + qsmCookieExpiryQRPOne.toUTCString();
-				document.cookie = "question_ids_<?php echo esc_js( $quiz_id ); ?>=" + "<?php echo esc_js( $question_sql ); ?>" + "; " + qmsExpiresQRPOne + "; path=/";
+				document.cookie = "question_ids_<?php echo esc_js( $quiz_id ); ?>=" + "<?php echo esc_js( $question_sql ); ?>" + "; " + qmsExpiresQRPOne + "; path=/<?php echo is_ssl() ? '; SameSite=None; Secure' : ''; ?>";
 			</script>
 			<?php
 		}
@@ -1495,7 +1495,7 @@ class QSM_New_Pagination_Renderer {
 				var qsmCookieExpiryQRPTwo = new Date();
 				qsmCookieExpiryQRPTwo.setTime(qsmCookieExpiryQRPTwo.getTime() + (365*24*60*60*1000));
 				var qmsExpiresQRPTwo = "expires="+ qsmCookieExpiryQRPTwo.toUTCString();
-				document.cookie = "question_ids_<?php echo esc_js( $this->options->quiz_id ); ?> = <?php echo esc_attr( implode( ',', $question_list ) ); ?>; "+qmsExpiresQRPTwo+"; path=/";
+				document.cookie = "question_ids_<?php echo esc_js( $this->options->quiz_id ); ?> = <?php echo esc_attr( implode( ',', $question_list ) ); ?>; "+qmsExpiresQRPTwo+"; path=/<?php echo is_ssl() ? '; SameSite=None; Secure' : ''; ?>";
 			</script>
 			<?php
 		}


### PR DESCRIPTION
The randomized question order is stored in the question_ids_<quiz_id> cookie and read back at scoring time. Without SameSite, Chromium's Lax default drops it inside a cross-site iframe (e.g. Google Sites), so submission finds no order and grades 0 of 0. Emit SameSite=None; Secure over HTTPS (guarded by is_ssl() to keep plain-HTTP first-party behavior).

### Merge Checklist

Please check all of the following items before merging

- [x] No new WPCS issues
- [x] No notices, warnings or errors in debug.log
- [x] No sonar cloud issues
- [x] No errors while running automated tests
