### PR TITLE
Fix navigator jump to unloaded page loading wrong questions (new render)

### DIFF
--- a/renderer/assets/js/qsm-quiz-navigation.js
+++ b/renderer/assets/js/qsm-quiz-navigation.js
@@ -855,7 +855,43 @@ if (typeof window.qsmCheckMR !== 'function') {
                 // Trigger after page change event
                 $(document).trigger('qsm_go_to_page_after', [quizId, pageNumber, quizData]);
             },
-            
+
+            /**
+             * Navigate to a QUESTION page by its 1-based question-page number.
+             *
+             * goToPage() indexes ALL `.qsm-page` sections (a welcome/first page and a
+             * trailing last page are included when present), while callers such as the
+             * Quiz Navigator addon think in question-page numbers (the `data-page` /
+             * `data-qpid` on `.qsm-question-page`). Translating with a fixed offset (e.g.
+             * always +1 for a welcome page) is wrong whenever that welcome page is not
+             * rendered — the jump then lands on the next section and lazy-loads the wrong
+             * page's questions. Resolve the target section's real position instead so the
+             * correct page (and its questions) always loads, regardless of which
+             * non-question pages exist.
+             *
+             * @param {number} quizId
+             * @param {number} questionPageNumber 1-based question-page number (data-page)
+             */
+            goToQuestionPage: function(quizId, questionPageNumber) {
+                let quizData = this.quizObjects[quizId];
+                if (!quizData) return;
+
+                let $target = quizData.quizContainer
+                    .find('.qsm-question-page[data-page="' + questionPageNumber + '"]').first();
+                if (!$target.length) {
+                    // Older markup uses data-qpid for the same 1-based question-page number.
+                    $target = quizData.quizContainer
+                        .find('.qsm-question-page[data-qpid="' + questionPageNumber + '"]').first();
+                }
+
+                // Position of the target within the full `.qsm-page` set drives goToPage's
+                // 1-based index. Fall back to positional if the section can't be found.
+                let index = quizData.pages.index($target);
+                let pageNumber = index >= 0 ? index + 1 : parseInt(questionPageNumber, 10);
+
+                this.goToPage(quizId, pageNumber);
+            },
+
             /**
              * Show specific page (helper method)
              */


### PR DESCRIPTION
## Problem
In the new render (`render_type == '11'`), jumping via the Quiz Navigator to a **not-yet-loaded** page displays the **wrong page's** questions. On a quiz with no welcome page, clicking page N shows page **N+1**; clicking a page near the end makes `goToPage` exceed the page count, its range guard rejects the call, and the quiz **stays on the last page you'd navigated to** — "the next page after the last previously loaded page."

## Root cause
`goToPage(pageNumber)` selects the target **positionally**: `quizData.pages.eq(pageNumber - 1)` over **all** `.qsm-page` sections, in DOM order `[ optional welcome page, Q1..QN, optional last page ]`. The welcome/first `.qsm-page` is rendered only when `should_show_first_page()` is true, and a last `.qsm-page` only when `should_show_last_page()`. The Quiz Navigator addon translated its question-page number to `goToPage`'s index with a hardcoded `+ 1`, assuming a welcome section always sits at index 0. When there's no welcome page that offset is wrong.

## Fix
Add `goToQuestionPage(quizId, questionPageNumber)` to the loader. It resolves the target `.qsm-question-page` by its `data-page`/`data-qpid` and drives `goToPage` with the section's **real position** in `.qsm-page`, so the correct page (and its lazy-loaded questions) always shows regardless of which non-question pages exist. Falls back to positional if the section can't be found. The addon delegates to this helper (separate PR in `qsm-addons`).

## Verification
Ran the **real** navigation methods (`goToPage`/`goToQuestionPage`/`showPage`/`preloadNextPages`/`loadPageQuestions`) against a faithful DOM with a stubbed `$.ajax` capturing which page's `question_ids` get requested, across welcome present/absent × last-page present/absent × single-jump and start-then-navigate-then-jump flows:
- **new `goToQuestionPage`**: 16/16 single-jump + 12/12 multi-step correct.
- **old `+1`**: fails every no-welcome-page case (8/16, 6/12).

## Companion
Addon PR: `QuizandSurveyMaster/qsm-addons` branch `CU-86d3ytduw-navigator-fix-unloaded-page-jump`. Please **do not merge yet**.

Agent OS session: https://ai.expresstech.io/#/sessions/aos-ses_a67880697adb7086
