### PR TITLE
fix(security): Plugin Check hardening Phase 1 — ABSPATH guards + input sanitization

### DIFF
--- a/assets/index.php
+++ b/assets/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 die("Error: Unauthorized Access");
 

--- a/css/index.php
+++ b/css/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 die("Error: Unauthorized Access");
 ?>

--- a/index.php
+++ b/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 die("Error: Unauthorized Access.");
 

--- a/js/index.php
+++ b/js/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 die("Error: Unauthorized Access");
 ?>

--- a/php/admin/create-quiz-page.php
+++ b/php/admin/create-quiz-page.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 // Add AJAX action for logged-in users
 add_action('wp_ajax_qsm_activate_plugin', 'qsm_activate_plugin_ajax_activate_plugin');

--- a/php/admin/functions.php
+++ b/php/admin/functions.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 $themes_data = array();
 global $pro_themes;
 $pro_themes  = array( 'qsm-theme-pool', 'qsm-theme-breeze', 'qsm-theme-fragrance', 'qsm-theme-ivory', 'qsm-theme-sigma', 'qsm-theme-fortune', 'qsm-theme-pixel', 'qsm-theme-sapience', 'Breeze', 'Fragrance', 'Pool', 'Ivory', 'Sigma', 'Fortune', 'Pixel', 'Sapience' );

--- a/php/admin/index.php
+++ b/php/admin/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 die("Error: Unauthorized Access");
 

--- a/php/backward-compatibility/qsm-backward-compatibility-template-variables.php
+++ b/php/backward-compatibility/qsm-backward-compatibility-template-variables.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 function qsm_bckcmp_tempvar_qa_text_qt_multi_choice_correct( $answers_from_db, $answers_from_response, $question_settings ) {
     $question_with_answer_text = '';

--- a/php/classes/class-qmn-review-message.php
+++ b/php/classes/class-qmn-review-message.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 /**
  * Class that handles displaying of review notice

--- a/php/default-templates.php
+++ b/php/default-templates.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 function qmn_register_default_templates() {
 	global $mlwQuizMasterNext;
 	$mlwQuizMasterNext->pluginHelper->register_quiz_template( 'Primary', 'qmn_primary.css');

--- a/php/gdpr.php
+++ b/php/gdpr.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 /**
  * This file handles elements needed for GDPR. This requires WordPress 4.9.6 or later. This includes:
  *

--- a/php/images/index.php
+++ b/php/images/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 die("Error: Unauthorized Access");
 

--- a/php/index.php
+++ b/php/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 die("Error: Unauthorized Access");
 

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 /**
  * This file handles all of the current REST API endpoints
  *

--- a/php/shortcodes.php
+++ b/php/shortcodes.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 /**
  * Resolve a QSM quiz_id to the qsm_quiz post ID for the CURRENT request language.

--- a/php/template-variables.php
+++ b/php/template-variables.php
@@ -1424,11 +1424,9 @@ function qsm_questions_answers_shortcode_to_text( $mlw_quiz_array, $qmn_question
 			}
 			// Lazy-loaded pages append their shuffled order here so the result
 			// page can render answers in the order the user saw.
-			if ( empty( $random_ids_for_question ) && ! empty( $_POST['qsm_lazy_answer_random_ids'][ $answer['id'] ] ) ) {
-				$lazy_keys = wp_unslash( $_POST['qsm_lazy_answer_random_ids'][ $answer['id'] ] );
-				if ( is_array( $lazy_keys ) ) {
-					$random_ids_for_question = array_map( 'intval', $lazy_keys );
-				}
+			if ( empty( $random_ids_for_question ) && ! empty( $_POST['qsm_lazy_answer_random_ids'][ $answer['id'] ] ) && is_array( $_POST['qsm_lazy_answer_random_ids'][ $answer['id'] ] ) ) {
+				// Sanitize on access: ids are cast to int via array_map( 'intval', ... ).
+				$random_ids_for_question = array_map( 'intval', wp_unslash( $_POST['qsm_lazy_answer_random_ids'][ $answer['id'] ] ) );
 			}
 			if ( ! empty( $random_ids_for_question ) ) {
 				$answers_random = array();

--- a/php/template-variables/qsm-tempvar-question-answers.php
+++ b/php/template-variables/qsm-tempvar-question-answers.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 function qsm_tempvar_qa_text_qt_choice( $total_answers, $answers_from_response, $grading_system, $question_settings, $form_type = 0 ) {
 	global $mlwQuizMasterNext;
 	$question_with_answer_text = '';


### PR DESCRIPTION
## Plugin Check security hardening — Phase 1 (safe, verifiable slice)

Part of the response to the **WordPress.org re-review for CVE-2026-11780**. The reported `question_title` stored XSS is already fixed & live in 11.2.3; this PR begins clearing the *other* Plugin Check security findings that the comprehensive re-review will re-scan.

### What this PR does (21 findings, zero behavioral risk)
- **`missing_direct_file_access_protection` (16 files):** add the canonical
  `if ( ! defined( 'ABSPATH' ) ) exit;` guard right after the opening tag.
  (`php/admin/admin-dashboard.php` was already guarded on dev — skipped.)
- **`WordPress.Security.ValidatedSanitizedInput.InputNotSanitized` (1):**
  `php/template-variables.php` — `$_POST['qsm_lazy_answer_random_ids']` is now
  sanitized *on access* via `array_map( 'intval', ... )` with an `is_array`
  guard on the raw value. **Behavior is identical** (still requires a non-empty
  array; each id is `intval`'d exactly as before).

### Deliberately NOT in this PR (needs per-case review — follow-up)
These are the judgment-heavy buckets that can't be safely batch-fixed blind on a live revenue plugin:
- **XSS — output not escaped (106)** — renderers echo assembled HTML; each needs
  per-value escaping (`esc_html`/`esc_attr`/`wp_kses_post`), not a blanket wrap.
- **CSRF — nonce (232)** — must verify whether each handler is already guarded upstream.
- **SQLi — not-prepared / unescaped-param (~470)** — the bulk in
  `class-qsm-install.php` / `class-qsm-database-migration.php` are **false positives**
  (schema DDL + already-`prepare()`d queries phpcs can't trace); the genuine ones
  need data-flow tracing.

### Verification note
This session had no PHP/phpcs runtime, so I could not re-run Plugin Check to confirm the count drop. Changes were verified by inspection; the ABSPATH guard is Plugin Check's documented remedy and the input-sanitization change preserves behavior. **Please re-run Plugin Check on the sandbox** (`qsm-play`) after merge to confirm these categories clear.

Agent OS session: https://ai.expresstech.io/#/sessions/aos-ses_3bbfc56272ab0da3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
