### PR TITLE
Fix Show-question-numbers drift after navigator jump to lazy pages (new render)

### DIFF
--- a/renderer/frontend/class-qsm-ajax-handler.php
+++ b/renderer/frontend/class-qsm-ajax-handler.php
@@ -148,6 +148,15 @@ class QSM_Ajax_Handler {
 			), ARRAY_A );
 
 			if ( $question ) {
+				// Skip unpublished (draft) questions, mirroring load_questions() in
+				// the pagination renderer, so a lazy-loaded page renders and numbers
+				// exactly the same set of questions the inline pages do. Without this
+				// an unpublished question would render on lazy pages only, throwing
+				// off the "Show question numbers" sequence after the jump.
+				$question_settings = maybe_unserialize( $question['question_settings'] );
+				if ( isset( $question_settings['isPublished'] ) && 1 !== intval( $question_settings['isPublished'] ) ) {
+					continue;
+				}
 				$questions[ $question_id ] = $question;
 			}
 		}

--- a/renderer/frontend/class-qsm-render-pagination.php
+++ b/renderer/frontend/class-qsm-render-pagination.php
@@ -1163,8 +1163,15 @@ class QSM_New_Pagination_Renderer {
 					</div>
 				</div>
 				<?php
-				// Increment question count for lazy loaded pages
-				$qmn_total_questions += count( $page );
+				// Increment question count for lazy loaded pages.
+				// Count only questions that will actually be rendered (present in
+				// $this->questions, i.e. not deleted/unpublished) so the running
+				// total — and therefore each later page's data-question-start-number —
+				// matches how the inline render and the lazy AJAX handler number
+				// questions. Using the raw $page array here would over-count when a
+				// page references a deleted/unpublished question and shift the numbers
+				// shown on every subsequent lazy-loaded page.
+				$qmn_total_questions += count( array_intersect( $page, array_keys( $this->questions ) ) );
 			}
 			// Show page count if enabled
 			if ( isset( $this->quiz_options->enable_pagination_quiz ) && 1 == $this->quiz_options->enable_pagination_quiz ) {


### PR DESCRIPTION
## What & why
Follow-up to the navigator jump fix (#3202). With that fix the Quiz Navigator lands on the **correct** question in new render (`render_type 11`), but with **Show question numbers** (`question_numbering`) enabled the displayed number was still wrong after a jump.

### How the number is calculated
Each page's first question number is computed once as **`$page_start_number` = (questions rendered on all preceding pages) + 1** — i.e. derived from the questions-per-page of the earlier pages plus this page's position — and stamped server-side as `data-question-start-number`. It's deterministic and **load-order independent**, so a direct jump (e.g. 1→10) shows the right number **without loading the pages in between**. This single calculation covers both:
- **Auto pagination** (a fixed number of questions per page), and
- **Manual pagination** (a *different* number of questions per page).

> Note: a literal `(page − 1) × questions_per_page` formula is intentionally **not** used — it only holds when every page has the same size, so it breaks for **category-based / manual** pagination. The cumulative per-page-count form above is the general, category-safe version.

### The bug
The running total feeding `$page_start_number` was advanced by the **raw** page array (`count($page)`) for lazy-loaded pages, while inline rendering and the lazy AJAX handler only render/number **valid** (non-deleted, published) questions. Any deleted/unpublished question in a page therefore shifted the number on **every subsequent lazy page**.

## Changes (core only)
- **`renderer/frontend/class-qsm-render-pagination.php`** — name the per-page start value (`$page_start_number`) and advance the running total by valid questions only: `count( array_intersect( $page, array_keys( $this->questions ) ) )` on lazy pages, matching how inline pages count.
- **`renderer/frontend/class-qsm-ajax-handler.php`** — skip **unpublished** questions on lazy pages too, mirroring `load_questions()`, so inline and lazy pages number the identical set (deleted was already handled via `deleted = 0`).

## Why not "preload all pages before jumping"
Numbers are static per-page attributes, not a client-side running counter — preloading pages 2–9 before showing page 10 changes nothing (page 10 reads the same attribute either way) and would defeat lazy loading.

## Verification
- Arithmetic simulated (5 pages, a deleted + an unpublished question): **before** → numbers drift `…5, 7, 9, 10`; **after** → correct `…5, 6, 7, 8`.
- ⚠️ **Not yet run on a live WordPress install — needs QA** on a new-render quiz with the Quiz Navigator, lazy loading on, and a quiz containing a deleted/unpublished question. Verify a direct jump shows the correct number, with and without a welcome page, for both auto and manual pagination. (No PHP runtime in the authoring environment.)

## Notes
- No version/changelog bump here — leave that to release bundling to avoid conflicts across the in-flight CU-86d3tyduw branches.
- Complements #3202 (jump target) and qsm-addons#206 (addon delegation).

Refs CU-86d3tyduw

Agent OS session: https://ai.expresstech.io/#/sessions/aos-ses_fe631ddbaf311813