### PR TITLE
fix(db): bind runtime queries with $wpdb->prepare() (split from #3212)

### DIFF
--- a/blocks/block.php
+++ b/blocks/block.php
@@ -493,8 +493,7 @@ if ( ! class_exists( 'QSMBlock' ) ) {
 					// checking if logic is updated to tables
 					$logic_updated = get_option( 'logic_rules_quiz_' . $quiz['quiz_id'] );
 					if ( $logic_updated ) {
-						$query      = $wpdb->prepare( "SELECT logic FROM {$wpdb->prefix}mlw_logic where quiz_id = %d", $quiz['quiz_id'] );
-						$logic_data = $wpdb->get_results( $query, ARRAY_N );
+						$logic_data = $wpdb->get_results( $wpdb->prepare( "SELECT logic FROM {$wpdb->prefix}mlw_logic where quiz_id = %d", $quiz['quiz_id'] ), ARRAY_N  );
 						$logics     = array();
 						if ( ! empty( $logic_data ) ) {
 							foreach ( $logic_data as $logic ) {
@@ -512,8 +511,7 @@ if ( ! class_exists( 'QSMBlock' ) ) {
 					}
 
 					// get themes setting
-					$query       = $wpdb->prepare( "SELECT A.theme, B.quiz_theme_settings, B.active_theme FROM {$wpdb->prefix}mlw_themes A, {$wpdb->prefix}mlw_quiz_theme_settings B where A.id = B.theme_id and B.quiz_id = %d", $quiz['quiz_id'] );
-					$themes_data = $wpdb->get_results( $query, ARRAY_N );
+					$themes_data = $wpdb->get_results( $wpdb->prepare( "SELECT A.theme, B.quiz_theme_settings, B.active_theme FROM {$wpdb->prefix}mlw_themes A, {$wpdb->prefix}mlw_quiz_theme_settings B where A.id = B.theme_id and B.quiz_id = %d", $quiz['quiz_id'] ), ARRAY_N  );
 					if ( ! empty( $themes_data ) ) {
 						$themes = array();
 						foreach ( $themes_data as $data ) {

--- a/php/admin/create-quiz-page.php
+++ b/php/admin/create-quiz-page.php
@@ -60,8 +60,7 @@ function qsm_get_activated_themes_ajax() {
     $theme_slug = isset($_POST['slug']) ? sanitize_text_field(wp_unslash( $_POST['slug'] ) ) : "";
 	$theme_slug = 'qsm-theme-'.$theme_slug;
 	global $wpdb;
-	$query = $wpdb->prepare("SELECT id FROM {$wpdb->prefix}mlw_themes WHERE theme = %s", $theme_slug);
-	$id = $wpdb->get_var($query);
+	$id = $wpdb->get_var( $wpdb->prepare("SELECT id FROM {$wpdb->prefix}mlw_themes WHERE theme = %s", $theme_slug) );
 	wp_send_json_success(array( 'id' => $id ));
     wp_die();
 }

--- a/php/admin/options-page-email-tab.php
+++ b/php/admin/options-page-email-tab.php
@@ -34,8 +34,7 @@ function qsm_options_emails_tab_content() {
 	$template_from_script = qsm_get_parsing_script_data( 'templates.json' );
 	$template_from_script = apply_filters( 'qsm_email_templates_list_before', $template_from_script, $quiz_id );
 	$table_name = $wpdb->prefix . 'mlw_quiz_output_templates';
-	$temlpate_sql = "SELECT * FROM {$table_name} WHERE template_type='email'";
-	$my_email_templates = $wpdb->get_results($temlpate_sql);
+	$my_email_templates = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE template_type = %s", 'email' ) );
 	$qsm_dependency_list = qsm_get_dependency_plugin_list();
 	
 	// Get default email template from global settings

--- a/php/admin/options-page-questions-tab.php
+++ b/php/admin/options-page-questions-tab.php
@@ -1483,8 +1483,7 @@ function qsm_delete_question_from_database() {
 		);
 
 		// Prepare the query
-		$query   = $wpdb->prepare( $query, $question_ids_to_delete );
-		$results = $wpdb->query( $query );
+		$results = $wpdb->query( $wpdb->prepare( $query, $question_ids_to_delete ) );
 		if ( $results ) {
 			if ( ! empty( $update_qpages_after_delete ) ) {
 				foreach ( $update_qpages_after_delete as $quiz_id => $aftervalue ) {
@@ -1594,7 +1593,9 @@ function qsm_process_to_update_qpages_after_unlink( $connected_question_ids ) {
 	$qpages_array       = array();
 	if ( ! empty( $comma_seprated_ids ) ) {
 		global $wpdb, $mlwQuizMasterNext;
-		$quiz_results = $wpdb->get_results( "SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN (" . $comma_seprated_ids . ')' );
+		$qsm_ids          = array_map( 'absint', array_unique( $connected_question_ids ) );
+		$qsm_placeholders = implode( ',', array_fill( 0, count( $qsm_ids ), '%d' ) );
+		$quiz_results     = $wpdb->get_results( $wpdb->prepare( "SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN ({$qsm_placeholders})", ...$qsm_ids ) );
 		if ( ! empty( $quiz_results ) ) {
 			foreach ( $quiz_results as $single_quiz ) {
 				$quiz_id = $single_quiz->quiz_id;

--- a/php/admin/options-page-results-page-tab.php
+++ b/php/admin/options-page-results-page-tab.php
@@ -33,8 +33,7 @@ function qsm_options_results_tab_content() {
 	$template_from_script = qsm_get_parsing_script_data( 'templates.json' );
 	$template_from_script = apply_filters( 'qsm_result_templates_list_before', $template_from_script, $quiz_id );
 	$table_name = $wpdb->prefix . 'mlw_quiz_output_templates';
-	$temlpate_sql = "SELECT * FROM {$table_name} WHERE template_type='result'";
-	$my_result_templates = $wpdb->get_results($temlpate_sql);
+	$my_result_templates = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE template_type = %s", 'result' ) );
 
 	$qsm_dependency_list = qsm_get_dependency_plugin_list();
 

--- a/php/admin/quizzes-page.php
+++ b/php/admin/quizzes-page.php
@@ -111,7 +111,9 @@ if ( ! class_exists( 'QSMQuizList' ) ) {
 						 */
 						$q_types         = array();
 						$invalid_types   = array();
-						$question_types  = $wpdb->get_results( "SELECT `question_type_new` as type FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN (" . implode( ',', $question_ids ) . ")" );
+						$qsm_ids          = array_map( 'absint', $question_ids );
+						$qsm_placeholders = implode( ',', array_fill( 0, count( $qsm_ids ), '%d' ) );
+						$question_types   = $wpdb->get_results( $wpdb->prepare( "SELECT `question_type_new` as type FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN ({$qsm_placeholders})", ...$qsm_ids ) );
 						if ( ! empty( $question_types ) ) {
 							foreach ( $question_types as $data ) {
 								$q_types[] = $data->type;

--- a/php/admin/settings-page.php
+++ b/php/admin/settings-page.php
@@ -1660,8 +1660,7 @@ class QMNGlobalSettingsPage {
 		$template_from_script = apply_filters( $filter, $template_from_script, $quiz_id );
 
 		$table_name = $wpdb->prefix . 'mlw_quiz_output_templates';
-		$template_sql = "SELECT * FROM {$table_name} WHERE template_type='global_{$type}'";
-		$my_templates = $wpdb->get_results( $template_sql );
+		$my_templates = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE template_type = %s", 'global_' . $type ) );
 
 		$qsm_dependency_list = qsm_get_dependency_plugin_list();
 

--- a/php/classes/class-qmn-log-manager.php
+++ b/php/classes/class-qmn-log-manager.php
@@ -202,8 +202,7 @@ class QMN_Log_Manager
 		
 		$sql .= " LIMIT 1";
 		
-		$query = $wpdb->prepare( $sql, $params );
-		$existing_log_id = $wpdb->get_var( $query );
+		$existing_log_id = $wpdb->get_var( $wpdb->prepare( $sql, $params ) );
 		
 		return $existing_log_id ? (int) $existing_log_id : false;
 	}

--- a/php/classes/class-qmn-quiz-creator.php
+++ b/php/classes/class-qmn-quiz-creator.php
@@ -591,8 +591,7 @@ class QMNQuizCreator {
 		$update_q_pages       = maybe_unserialize( $update_quiz_settings['qpages'] );
 		// get logic data from logic table first or else from quiz_settings
 		if ( ! is_null( $logic_table_exists ) ) {
-			$query       = $wpdb->prepare( "SELECT * FROM $logic_table WHERE quiz_id = %d", $quiz_id );
-			$logic_data  = $wpdb->get_results( $query );
+			$logic_data  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $logic_table WHERE quiz_id = %d", $quiz_id ) );
 			$logic_rules = array();
 			if ( ! empty( $logic_data ) ) {
 				foreach ( $logic_data as $data ) {
@@ -718,8 +717,7 @@ class QMNQuizCreator {
 				// Copying categories for multiple categories table
 				$new_question_id = $wpdb->insert_id;
 				if ( ! is_null( $question_term_exists ) ) {
-					$query    = $wpdb->prepare( "SELECT DISTINCT term_id FROM $question_term WHERE question_id = %d AND quiz_id = %d", $mlw_question->question_id, $quiz_id );
-					$term_ids = $wpdb->get_results( $query, ARRAY_N );
+					$term_ids = $wpdb->get_results( $wpdb->prepare( "SELECT DISTINCT term_id FROM $question_term WHERE question_id = %d AND quiz_id = %d", $mlw_question->question_id, $quiz_id ), ARRAY_N  );
 
 					if ( ! is_null( $term_ids ) ) {
 						foreach ( $term_ids as $term_id ) {

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -808,8 +808,7 @@ class QMNQuizManager {
 		$category_question_ids = array();
 		if ( $multiple_category_system && ! empty( $exploded_arr ) ) {
 			$term_ids      = implode( ', ', $exploded_arr );
-			$query         = $wpdb->prepare( "SELECT DISTINCT question_id FROM {$wpdb->prefix}mlw_question_terms WHERE quiz_id = %d AND term_id IN (%1s)", $quiz_id, $term_ids );
-			$question_data = $wpdb->get_results( $query, ARRAY_N );
+			$question_data = $wpdb->get_results( $wpdb->prepare( "SELECT DISTINCT question_id FROM {$wpdb->prefix}mlw_question_terms WHERE quiz_id = %d AND term_id IN (%1s)", $quiz_id, $term_ids ), ARRAY_N  );
 			foreach ( $question_data as $q_data ) {
 				$category_question_ids[] = $q_data[0];
 			}
@@ -981,8 +980,7 @@ class QMNQuizManager {
 				$question_sql = implode(',', $question_ids);
 				$order_by_sql = "ORDER BY FIELD(question_id, ".esc_sql($question_sql).")";
 			}
-			$query          = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE question_id IN (%1s) %2s %3s %4s", esc_sql( $question_sql ), esc_sql( $cat_query ), esc_sql( $order_by_sql ), esc_sql( $limit_sql ) );
-			$questions      = $wpdb->get_results( $query );
+			$questions      = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE question_id IN (%1s) %2s %3s %4s", esc_sql( $question_sql ), esc_sql( $cat_query ), esc_sql( $order_by_sql ), esc_sql( $limit_sql ) ) );
 			$question_order = array();
 			if ( ! empty( $question_ids ) ) {
 				foreach ( $question_ids as $question_id_order ) {
@@ -2462,8 +2460,7 @@ class QMNQuizManager {
                             category, multicategories, other_settings)
                             VALUES " . implode( ', ', $placeholders );
                         
-                        $prepared = $wpdb->prepare( $sql, ...$params );
-                        $inserted = $wpdb->query( $prepared );
+                        $inserted = $wpdb->query( $wpdb->prepare( $sql, ...$params ) );
 
                         if ( false == $inserted || 0 == $inserted ) {
                             $transaction_failed = true;
@@ -2551,8 +2548,7 @@ class QMNQuizManager {
                     (result_id, meta_key, meta_value)
                     VALUES " . implode( ', ', $meta_placeholders );
 
-                $prepared_meta = $wpdb->prepare( $meta_sql, ...$meta_params );
-                $meta_inserted = $wpdb->query( $prepared_meta );
+                $meta_inserted = $wpdb->query( $wpdb->prepare( $meta_sql, ...$meta_params ) );
                 
                 if ( false == $meta_inserted || 0 == $meta_inserted ) {
                     throw new Exception('Meta inserts failed.');

--- a/php/classes/class-qsm-questions.php
+++ b/php/classes/class-qsm-questions.php
@@ -385,7 +385,8 @@ class QSM_Questions
             $sanitized_linked_ids = array_map('intval', array_unique($linked_questions_array));
             $imploded_question_ids = implode(',', $sanitized_linked_ids);
             if ( ! empty($sanitized_linked_ids) ) {
-                $quiz_results = $wpdb->get_results("SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN (" . $imploded_question_ids . ")");
+                $qsm_placeholders = implode(',', array_fill(0, count($sanitized_linked_ids), '%d'));
+                $quiz_results = $wpdb->get_results($wpdb->prepare("SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN ({$qsm_placeholders})", ...$sanitized_linked_ids));
                 foreach ( $quiz_results as $key => $value ) {
                     $quiz_questions_array[ $value->quiz_id ] = $value->question_id;
                 }

--- a/php/classes/class-qsm-theme-settings.php
+++ b/php/classes/class-qsm-theme-settings.php
@@ -206,8 +206,7 @@ class QSM_Theme_Settings {
 	 */
 	public function get_active_quiz_theme( $quiz_id ) {
 		global $wpdb;
-		$query  = $wpdb->prepare( "SELECT theme_id FROM {$wpdb->prefix}$this->settings_table WHERE quiz_id = %d AND active_theme = 1", $quiz_id );
-		$result = $wpdb->get_var( $query );
+		$result = $wpdb->get_var( $wpdb->prepare( "SELECT theme_id FROM {$wpdb->prefix}$this->settings_table WHERE quiz_id = %d AND active_theme = 1", $quiz_id ) );
 		return $result ? $result : 0;
 	}
 
@@ -217,8 +216,7 @@ class QSM_Theme_Settings {
 	public function get_active_quiz_theme_path( $quiz_id ) {
 		global $wpdb;
 		global $mlwQuizMasterNext;
-		$query  = $wpdb->prepare( "SELECT a.theme FROM {$wpdb->prefix}$this->themes_table AS a, {$wpdb->prefix}$this->settings_table AS b WHERE b.quiz_id = %d AND b.active_theme = 1 AND b.theme_id = a.id", $quiz_id );
-		$result = $wpdb->get_var( $query );
+		$result = $wpdb->get_var( $wpdb->prepare( "SELECT a.theme FROM {$wpdb->prefix}$this->themes_table AS a, {$wpdb->prefix}$this->settings_table AS b WHERE b.quiz_id = %d AND b.active_theme = 1 AND b.theme_id = a.id", $quiz_id ) );
 		$active_themes = $mlwQuizMasterNext->theme_settings->get_active_themes();
 		$theme_path = 'default';
 		$themes = array();
@@ -238,8 +236,7 @@ class QSM_Theme_Settings {
 	 */
 	public function get_active_theme_settings( $quiz_id, $theme_id ) {
 		global $wpdb;
-		$query  = $wpdb->prepare( "SELECT quiz_theme_settings FROM {$wpdb->prefix}$this->settings_table WHERE quiz_id = %d AND theme_id = %d", $quiz_id, $theme_id );
-		$result = $wpdb->get_var( $query );
+		$result = $wpdb->get_var( $wpdb->prepare( "SELECT quiz_theme_settings FROM {$wpdb->prefix}$this->settings_table WHERE quiz_id = %d AND theme_id = %d", $quiz_id, $theme_id ) );
 		return maybe_unserialize( $result );
 	}
 

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -212,8 +212,7 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 		$question_ids = array();
 		if ( ! empty( $category ) ) {
 			if ( $migrated && is_numeric( $category ) ) {
-				$query    = $wpdb->prepare( "SELECT DISTINCT question_id FROM {$wpdb->prefix}mlw_question_terms WHERE term_id = %d", $category );
-				$term_ids = $wpdb->get_results( $query, 'ARRAY_A' );
+				$term_ids = $wpdb->get_results( $wpdb->prepare( "SELECT DISTINCT question_id FROM {$wpdb->prefix}mlw_question_terms WHERE term_id = %d", $category ), 'ARRAY_A'  );
 				foreach ( $term_ids as $term_id ) {
 					$question_ids[] = esc_sql( intval( $term_id['question_id'] ) );
 				}
@@ -244,20 +243,17 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 				$query_result = array();
 				foreach ( $question_ids as $question_id ) {
 					$query = "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND question_id = %d AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d";
-					$query = $wpdb->prepare( $query, $question_id, $quiz_filter, $offset, $limit );
-					$question_data = $wpdb->get_row( $query, 'ARRAY_A' );
+					$question_data = $wpdb->get_row( $wpdb->prepare( $query, $question_id, $quiz_filter, $offset, $limit ), 'ARRAY_A'  );
 					if ( ! is_null( $question_data ) ) {
 						$query_result[] = $question_data;
 					}
 				}
 				$questions = $query_result;
 			} else {
-				$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d", $category, $quiz_filter, $offset, $limit );
-				$questions = $wpdb->get_results( $query, 'ARRAY_A' );
+				$questions = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d", $category, $quiz_filter, $offset, $limit ), 'ARRAY_A'  );
 			}
 		} else {
-			$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d", $quiz_filter, $offset, $limit );
-			$questions = $wpdb->get_results( $query, 'ARRAY_A' );
+			$questions = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d", $quiz_filter, $offset, $limit ), 'ARRAY_A'  );
 		}
 
 		$question_array               = array();
@@ -598,7 +594,9 @@ function qsm_rest_get_question( WP_REST_Request $request ) {
 				if ( ! empty( $linked_ids ) ) {
 					$linked_ids  = array_map( 'intval', $linked_ids );
 					$ids_list    = implode( ',', $linked_ids );
-					$quiz_results = $wpdb->get_results( "SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN (" . $ids_list . ")" );
+					$qsm_ids          = array_map( 'absint', $linked_ids );
+					$qsm_placeholders = implode( ',', array_fill( 0, count( $qsm_ids ), '%d' ) );
+					$quiz_results     = $wpdb->get_results( $wpdb->prepare( "SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN ({$qsm_placeholders})", ...$qsm_ids ) );
 					foreach ( $quiz_results as $value ) {
 						$quiz_name_in_loop        = $wpdb->get_row( $wpdb->prepare( "SELECT quiz_name FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d", $value->quiz_id ), ARRAY_A );
 						$quiz_name_in_loop = isset( $quiz_name_in_loop['quiz_name'] ) ? $quiz_name_in_loop['quiz_name'] : '';
@@ -668,7 +666,9 @@ function qsm_rest_get_questions( WP_REST_Request $request ) {
 				$stored_quiz_names[ $question['question_id'] ] = $quiz_name;
 				$linked_question_ids = array_filter( array_map( 'intval', isset( $question['linked_question'] ) ? explode(',', $question['linked_question']) : array() ) );
 				if ( ! empty($linked_question_ids) ) {
-					$quiz_results = $wpdb->get_results( "SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN (" . implode( ',', $linked_question_ids ) . ")" );
+					$qsm_ids          = array_map( 'absint', $linked_question_ids );
+					$qsm_placeholders = implode( ',', array_fill( 0, count( $qsm_ids ), '%d' ) );
+					$quiz_results     = $wpdb->get_results( $wpdb->prepare( "SELECT `quiz_id`, `question_id` FROM `{$wpdb->prefix}mlw_questions` WHERE `question_id` IN ({$qsm_placeholders})", ...$qsm_ids ) );
 					foreach ( $quiz_results as $value ) {
 						if ( ! in_array($value->question_id, $procesed_question_ids, true) ) {
 							$quiz_name_in_loop        = $wpdb->get_row( $wpdb->prepare( "SELECT quiz_name FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d", $value->quiz_id ), ARRAY_A );


### PR DESCRIPTION
## Runtime query binding — split out of #3212 per review

#3212 was correctly flagged as mixing verified schema/install work with application-flow changes. **#3212 is now strictly the schema/install path (4 files);** this PR carries the 13 runtime files so they can be reviewed and tested on their own.

### What's here
**1. Inlined `prepare()`-then-call pairs** — theme-settings, rest-api, quiz-manager, quiz-creator, questions-tab, create-quiz-page, log-manager, blocks
```diff
-$query  = $wpdb->prepare( "SELECT ... WHERE quiz_id = %d", $quiz_id );
-$result = $wpdb->get_var( $query );
+$result = $wpdb->get_var( $wpdb->prepare( "SELECT ... WHERE quiz_id = %d", $quiz_id ) );
```
Applied **only** where the assignment was a single line immediately before the call, so each is provably equivalent. Afterwards I checked for variables left referenced-but-unassigned and for nested `prepare()` calls — none.

**2. `IN()` lists via generated placeholders** — options-page-questions-tab, rest-api ×2, class-qsm-questions, quizzes-page
```diff
-"... WHERE question_id IN (" . implode( ',', $ids ) . ")"
+$ph = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+$wpdb->prepare( "... WHERE question_id IN ({$ph})", ...$ids )
```
Ids `absint()`-cast. Every site was confirmed to already sit inside a `! empty()` guard, since `array_fill( 0, 0, … )` would yield `IN ()` and a syntax error.

**3. Output-template lookups bound as `%s`** — options-page-email-tab, options-page-results-page-tab, settings-page. The last previously interpolated `$type` into the SQL; it's an internal `'email'|'result'` argument, not request input, so not exploitable — now bound regardless.

### Explicitly NOT included
The `stripslashes()` wrappers around `prepare()` calls using `%1s`/`%2s` **SQL-fragment** placeholders are left untouched. Review was right that these are load-bearing — `prepare()` escapes the fragment and `stripslashes()` restores it — so removing them would break quiz listing, duplication and category migration. I had removed them in #3212 and have reverted that.

### Verification — this branch deployed alone on a live sandbox
| flow | result |
|---|---|
| Quiz listing | renders, quiz present, no SQL error |
| **Quiz duplication (with questions)** | duplicate created; **copied quiz's question present via REST**; no SQL error |
| Results search with `O'Brien` | no SQL error |
| Question Bank / Questions tab | no SQL error |
| REST `questions?quizID=1` and `=2` | 200, items returned, no SQL error |
| Front-end quiz render | signature identical to baseline |

Fixture: quiz + question + a page carrying `[qsm quiz=1]` on WP 7.0.2.

### Still untested (flagging honestly)
- **author-role** quiz listing — I tested as administrator only; the `%1s` author-filter fragment is untouched by this PR, but the listing query around it was inlined.
- **category migration** — I could not trigger a migration on this sandbox; `class-qsm-migrate.php` is **not** in this PR (its only change was the reverted `stripslashes`), so the migration path should be unaffected.

Base: `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)