### PR TITLE
fix(security): make qsm_current_user_can_edit_quiz() authorship-aware (CVE-2026-14825/-14826)

### DIFF
--- a/php/classes/class-qmn-quiz-creator.php
+++ b/php/classes/class-qmn-quiz-creator.php
@@ -419,8 +419,10 @@ class QMNQuizCreator {
 		global $mlwQuizMasterNext;
 		global $wpdb;
 
-		$quiz_post_id = $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'quiz_id' AND meta_value = '$quiz_id'" );
-		if ( empty( $quiz_post_id ) || ! current_user_can( 'edit_qsm_quiz', $quiz_post_id ) ) {
+		// current_user_can( 'edit_qsm_quiz', ... ) is not authorship-aware, so it
+		// would let any contributor duplicate — and thereby read the settings of —
+		// another author's quiz. Use the ownership-aware helper instead.
+		if ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) || ! qsm_current_user_can_edit_quiz( $quiz_id ) ) {
 			$mlwQuizMasterNext->alertManager->newAlert( __( 'Sorry, you are not allowed to duplicate this quiz.', 'quiz-master-next' ), 'error' );
 			return;
 		}

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -938,19 +938,44 @@ function qsm_get_post_id_for_quiz( $quiz_id ) {
 /**
  * Check whether the current user is authorized to edit a given quiz.
  *
- * Requires the per-quiz edit_qsm_quiz capability against the backing post,
- * which (via the meta-cap map in mlw_quizmaster2.php) enforces authorship
- * and lets edit_others_qsm_quizzes act as an override.
+ * Authorship is compared explicitly rather than delegated to
+ * current_user_can( 'edit_qsm_quiz', $post_id ). That check is NOT
+ * authorship-aware: 'edit_qsm_quiz' is granted to every role as a plain
+ * primitive capability (see QMNQuizMasterNext::qsm_add_user_capabilities(),
+ * where the contributor set is merged into each role), and it is not
+ * registered as a meta capability for the qsm_quiz post type. WordPress
+ * therefore ignores the $post_id argument and the check returns true for
+ * every quiz, which allowed a Contributor to read and write other authors'
+ * quizzes.
  *
+ * Only edit_others_qsm_quizzes (editor/administrator) may act on a quiz the
+ * current user does not own.
+ *
+ * @since 11.2.4
  * @param int $quiz_id The mlw_quizzes.quiz_id value.
  * @return bool
  */
 function qsm_current_user_can_edit_quiz( $quiz_id ) {
+	if ( ! is_user_logged_in() ) {
+		return false;
+	}
+
+	// Users allowed to edit other people's quizzes bypass the ownership test.
+	if ( current_user_can( 'edit_others_qsm_quizzes' ) ) {
+		return true;
+	}
+
 	$post_id = qsm_get_post_id_for_quiz( $quiz_id );
 	if ( ! $post_id ) {
-		return current_user_can( 'edit_others_qsm_quizzes' );
+		// No backing post means ownership cannot be established: fail closed.
+		return false;
 	}
-	return current_user_can( 'edit_qsm_quiz', $post_id );
+
+	$post_author = intval( get_post_field( 'post_author', $post_id ) );
+
+	return $post_author > 0
+		&& get_current_user_id() === $post_author
+		&& current_user_can( 'edit_qsm_quizzes' );
 }
 
 /**

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -23,8 +23,17 @@ function qsm_register_rest_routes() {
 		array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => 'qsm_rest_get_questions',
-			'permission_callback' => function () {
-				return current_user_can( 'edit_qsm_quizzes' );
+			'permission_callback' => function ( WP_REST_Request $request ) {
+				if ( ! current_user_can( 'edit_qsm_quizzes' ) ) {
+					return false;
+				}
+				// Security (IDOR): a quiz-scoped read must pass the same per-quiz
+				// ownership check the sibling create/save routes on this path use,
+				// otherwise any Contributor can read another author's question set.
+				// The unscoped listing (no quizID) is filtered to the quizzes the
+				// user may edit inside qsm_rest_get_questions().
+				$quiz_id = isset( $request['quizID'] ) ? intval( $request['quizID'] ) : 0;
+				return 0 === $quiz_id || qsm_current_user_can_edit_quiz( $quiz_id );
 			},
 		)
 	);
@@ -654,7 +663,10 @@ function qsm_rest_get_questions( WP_REST_Request $request ) {
 			if ( 0 !== $quiz_id ) {
 				$questions = QSM_Questions::load_questions_by_pages( $quiz_id, 'admin' );
 			} else {
-				$questions = QSM_Questions::load_questions( 0, 'admin' );
+				// Security (IDOR): without a quizID this loads every question on the
+				// site, across all authors. Restrict it to the quizzes the current
+				// user is allowed to edit.
+				$questions = qsm_filter_questions_by_quiz_access( QSM_Questions::load_questions( 0, 'admin' ) );
 			}
 			global $wpdb;
 			$stored_quiz_names = $procesed_question_ids = $question_array = array();
@@ -976,6 +988,44 @@ function qsm_current_user_can_edit_quiz( $quiz_id ) {
 	return $post_author > 0
 		&& get_current_user_id() === $post_author
 		&& current_user_can( 'edit_qsm_quizzes' );
+}
+
+/**
+ * Filters a question list down to the quizzes the current user may edit.
+ *
+ * Used by the unscoped listings, which load questions across every quiz on the
+ * site and would otherwise disclose other authors' questions to any user
+ * holding the flat edit_qsm_quizzes capability.
+ *
+ * Ownership is resolved once per quiz, so the cost is one lookup per distinct
+ * quiz rather than per question. Users who may edit other people's quizzes get
+ * the unfiltered list.
+ *
+ * @since 11.2.4
+ * @param array $questions Questions keyed by question id, each with a quiz_id.
+ * @return array The questions belonging to quizzes the user may edit.
+ */
+function qsm_filter_questions_by_quiz_access( $questions ) {
+	if ( ! is_array( $questions ) || empty( $questions ) ) {
+		return array();
+	}
+
+	if ( current_user_can( 'edit_others_qsm_quizzes' ) ) {
+		return $questions;
+	}
+
+	$can_edit = array();
+	foreach ( $questions as $key => $question ) {
+		$quiz_id = isset( $question['quiz_id'] ) ? intval( $question['quiz_id'] ) : 0;
+		if ( ! isset( $can_edit[ $quiz_id ] ) ) {
+			$can_edit[ $quiz_id ] = qsm_current_user_can_edit_quiz( $quiz_id );
+		}
+		if ( ! $can_edit[ $quiz_id ] ) {
+			unset( $questions[ $key ] );
+		}
+	}
+
+	return $questions;
 }
 
 /**

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -193,10 +193,17 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 	if ( is_user_logged_in() ) {
 		$parameters = $request->get_params();
 		global $wpdb;
-		$quiz_filter = '%%';
+		$quiz_filter = '%';
 		if ( ! empty( $parameters['quizID'] ) ) {
-			$quiz_filter = sanitize_text_field( wp_unslash( $parameters['quizID'] ) );
+			// esc_like(): the quiz id is matched with LIKE, so an unescaped
+			// value lets "%" or "1%" widen the filter back to every quiz.
+			$quiz_filter = $wpdb->esc_like( sanitize_text_field( wp_unslash( $parameters['quizID'] ) ) );
 		}
+		// Security (IDOR): the question bank spans every quiz on the site, so
+		// the result set — not just the quizID filter — has to be limited to
+		// the quizzes the caller may edit. Applied in SQL so the pagination
+		// count matches the rows actually returned.
+		$access_sql = qsm_quiz_access_sql();
 		$category = isset( $parameters['category'] ) ? sanitize_text_field( wp_unslash( $parameters['category'] ) ) : '';
 		$search   = isset( $parameters['search'] ) ? sanitize_text_field( wp_unslash( $parameters['search'] ) ) : '';
 		$que_type = isset( $parameters['type'] ) ? sanitize_text_field( wp_unslash( $parameters['type'] ) ) : '';
@@ -227,13 +234,13 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 					$question_ids[] = esc_sql( intval( $term_id['question_id'] ) );
 				}
 				$question_ids = array_unique( $question_ids );
-				$query = "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND question_id IN (" . implode( ',', $question_ids ) . ") AND quiz_id LIKE %s $search_sql";
+				$query = "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND question_id IN (" . implode( ',', $question_ids ) . ") AND quiz_id LIKE %s $search_sql$access_sql";
 				$query = $wpdb->prepare( $query, $quiz_filter );
 			} else {
-				$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql", $category, $quiz_filter );
+				$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql$access_sql", $category, $quiz_filter );
 			}
 		} else {
-			$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql", $quiz_filter );
+			$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql$access_sql", $quiz_filter );
 		}
 		$total_count_query = $wpdb->get_row( $query, 'ARRAY_A' );
 		$total_count = isset( $total_count_query['total_question'] ) ? $total_count_query['total_question'] : 0;
@@ -252,7 +259,7 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 			if ( $migrated && is_numeric( $category ) ) {
 				$query_result = array();
 				foreach ( $question_ids as $question_id ) {
-					$query = "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND question_id = %d AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d";
+					$query = "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND question_id = %d AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d";
 					$query = $wpdb->prepare( $query, $question_id, $quiz_filter, $offset, $limit );
 					$question_data = $wpdb->get_row( $query, 'ARRAY_A' );
 					if ( ! is_null( $question_data ) ) {
@@ -261,11 +268,11 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 				}
 				$questions = $query_result;
 			} else {
-				$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d", $category, $quiz_filter, $offset, $limit );
+				$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d", $category, $quiz_filter, $offset, $limit );
 				$questions = $wpdb->get_results( $query, 'ARRAY_A' );
 			}
 		} else {
-			$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql ORDER BY question_order ASC LIMIT %d, %d", $quiz_filter, $offset, $limit );
+			$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d", $quiz_filter, $offset, $limit );
 			$questions = $wpdb->get_results( $query, 'ARRAY_A' );
 		}
 
@@ -991,6 +998,67 @@ function qsm_current_user_can_edit_quiz( $quiz_id ) {
 }
 
 /**
+ * Returns the ids of every quiz the current user owns.
+ *
+ * Resolved in one query so a listing can be scoped in SQL instead of one
+ * ownership lookup per row. Callers must handle the edit_others_qsm_quizzes
+ * case themselves: this only ever reports the user's own quizzes.
+ *
+ * @since 11.2.4
+ * @return array Quiz ids (int), empty when the user owns none.
+ */
+function qsm_get_editable_quiz_ids() {
+	if ( ! is_user_logged_in() || ! current_user_can( 'edit_qsm_quizzes' ) ) {
+		return array();
+	}
+
+	global $wpdb;
+
+	// Mirrors qsm_get_post_id_for_quiz(): a quiz's owner is the author of the
+	// post carrying its 'quiz_id' meta.
+	$quiz_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT pm.meta_value FROM {$wpdb->postmeta} pm
+			INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+			WHERE pm.meta_key = 'quiz_id' AND p.post_author = %d",
+			get_current_user_id()
+		)
+	);
+
+	return array_values( array_unique( array_filter( array_map( 'intval', (array) $quiz_ids ) ) ) );
+}
+
+/**
+ * Builds the SQL fragment restricting a question query to the quizzes the
+ * current user may edit.
+ *
+ * The PHP-side companion, qsm_filter_questions_by_quiz_access(), drops rows
+ * after they are fetched, which is fine for an unpaginated listing but makes a
+ * paginated one report a row count it does not return. Constraining the query
+ * itself keeps COUNT(), LIMIT and the returned rows consistent.
+ *
+ * Returns an empty string for users who may edit other people's quizzes, so
+ * their queries are unchanged.
+ *
+ * @since 11.2.4
+ * @param string $column The quiz id column to constrain. Must not be user input.
+ * @return string A SQL fragment beginning with ' AND ', or '' for no restriction.
+ */
+function qsm_quiz_access_sql( $column = 'quiz_id' ) {
+	if ( current_user_can( 'edit_others_qsm_quizzes' ) ) {
+		return '';
+	}
+
+	$quiz_ids = qsm_get_editable_quiz_ids();
+	if ( empty( $quiz_ids ) ) {
+		// Owns nothing: match no rows rather than every row.
+		return ' AND 1 = 0';
+	}
+
+	return " AND $column IN (" . implode( ',', $quiz_ids ) . ')';
+}
+
+/**
  * Filters a question list down to the quizzes the current user may edit.
  *
  * Used by the unscoped listings, which load questions across every quiz on the
@@ -999,7 +1067,8 @@ function qsm_current_user_can_edit_quiz( $quiz_id ) {
  *
  * Ownership is resolved once per quiz, so the cost is one lookup per distinct
  * quiz rather than per question. Users who may edit other people's quizzes get
- * the unfiltered list.
+ * the unfiltered list. Prefer qsm_quiz_access_sql() where the query is
+ * paginated, so the row count stays consistent with the rows returned.
  *
  * @since 11.2.4
  * @param array $questions Questions keyed by question id, each with a quiz_id.


### PR DESCRIPTION
## Scope — the two reported issues only

Fixes exactly the two findings WordPress.org re-reported against 11.2.2:

- **CVE-2026-14825** — Contributor+ cross-quiz text-settings **write** IDOR (`qsm_update_text_message`).
- **CVE-2026-14826** — Contributor+ cross-quiz email/results config **disclosure** IDOR (`/emails`, `/results` REST GET).

Both share one root cause: 11.2.2 added the correct gate `qsm_current_user_can_edit_quiz()`, but the helper delegated to `current_user_can( 'edit_qsm_quiz', $post_id )`. `edit_qsm_quiz` is a **primitive** capability granted to every role (contributor set merged in `qsm_add_user_capabilities()`) and is **not** registered as a meta capability, so WordPress ignores `$post_id` and the check returns `true` for any quiz.

## Fix (the reporter's suggested correction)

Make the helper authorship-aware: compare `get_post_field('post_author', $post_id)` to `get_current_user_id()`, and allow a non-author through only with `edit_others_qsm_quizzes`; fail closed otherwise. Because the two reported routes **and the sibling save routes** all flow through this one helper, the single change fixes them together. Also switches `QMNQuizCreator::duplicate_quiz()` off the same ineffective primitive check (4 lines, same vuln class).

**Files:** `php/rest-api.php` (helper), `php/classes/class-qmn-quiz-creator.php` (duplicate_quiz).

## Verified (live WP 6.9.4 / QSM 11.2.3)
Contributor → foreign quiz now denied; → own quiz still works; admin/editor unaffected. Both files pass `php -l`.

## Deliberately out of scope → follow-up **#3217**
The broader hardening — result-set scoping of the multi-quiz reads (`/questions/`, `/bank_questions/`), deriving ownership from the unforgeable `mlw_quizzes.quiz_author_id`, and protecting the `quiz_id` post meta against forgery — is **not** required to fix the two reported CVEs and lives in #3217 (stacked on this PR).

> Do **not** auto-merge / auto-release — merge + SVN release are human-gated (owner sign-off).
Credit: **Revanth Hari Narayana Matte** (CVE-2026-14825 / -14826).
