### PR TITLE
fix(security): bank_questions IDOR (reported, CWE-639) + cross-quiz ownership hardening (follow-up to #3216)

### DIFF
--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -382,6 +382,37 @@ class MLWQuizMasterNext {
 		add_filter( 'manage_edit-qsm_category_columns', array( $this, 'modify_qsm_category_columns' ) );
 		add_action( 'wp_ajax_qsm_mark_setup_wizard_completed', array( $this, 'qsm_mark_setup_wizard_completed' ) );
 		add_action( 'wp_ajax_qsm_reset_setup_wizard_completed', array( $this, 'qsm_reset_setup_wizard_completed' ) );
+		add_filter( 'is_protected_meta', array( $this, 'qsm_protect_quiz_meta' ), 10, 3 );
+	}
+
+	/**
+	 * Marks the 'quiz_id' post meta as protected.
+	 *
+	 * The key ties a post to a quiz and is what the plugin resolves ownership
+	 * against. Without a leading underscore WordPress considers it public, so
+	 * the classic Custom Fields metabox would let anyone who can edit a post --
+	 * a Contributor editing their own draft, for instance -- attach another
+	 * author's quiz id to it and be mistaken for that quiz's owner. Protecting
+	 * the key makes wp-admin's add_meta() refuse it and hides it from the
+	 * metabox, while leaving the plugin's own add_post_meta() call in
+	 * QMNQuizCreator (which does not consult protection) unaffected.
+	 *
+	 * This shuts the entry point. It is not the whole defence -- ownership is
+	 * read from mlw_quizzes.quiz_author_id in qsm_current_user_can_edit_quiz()
+	 * so that a forged mapping arriving by some other route still grants
+	 * nothing.
+	 *
+	 * @since 11.2.4
+	 * @param bool   $protected Whether the key is protected.
+	 * @param string $meta_key  The meta key being checked.
+	 * @param string $meta_type The object type the meta belongs to.
+	 * @return bool
+	 */
+	public function qsm_protect_quiz_meta( $protected, $meta_key, $meta_type ) {
+		if ( 'post' === $meta_type && 'quiz_id' === $meta_key ) {
+			return true;
+		}
+		return $protected;
 	}
 
 	/**

--- a/php/admin/options-page-questions-tab.php
+++ b/php/admin/options-page-questions-tab.php
@@ -30,7 +30,11 @@ add_action( 'init', 'qsm_settings_questions_tab', 5 );
  */
 function qsm_options_questions_tab_content() {
 	global $wpdb, $mlwQuizMasterNext;
-	$quiz_data           = $wpdb->get_results( 'SELECT quiz_id, quiz_name	FROM ' . $wpdb->prefix . 'mlw_quizzes WHERE deleted=0 ORDER BY quiz_id DESC' );
+	// Scope the import-from-bank quiz picker to the quizzes the current user may
+	// edit, so a Contributor is not shown (and cannot pull from) other authors'
+	// quizzes. Users with edit_others_qsm_quizzes get the unfiltered list.
+	$qb_access           = function_exists( 'qsm_quiz_access_sql' ) ? qsm_quiz_access_sql() : '';
+	$quiz_data           = $wpdb->get_results( 'SELECT quiz_id, quiz_name FROM ' . $wpdb->prefix . 'mlw_quizzes WHERE deleted=0' . $qb_access . ' ORDER BY quiz_id DESC' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $qb_access is built from intval()ed ids in qsm_quiz_access_sql()
 	$question_categories = $wpdb->get_results( "SELECT DISTINCT category FROM {$wpdb->prefix}mlw_questions", 'ARRAY_A' );
 	$enabled             = get_option( 'qsm_multiple_category_enabled' );
 

--- a/php/admin/options-page-questions-tab.php
+++ b/php/admin/options-page-questions-tab.php
@@ -1099,21 +1099,15 @@ function qsm_user_can_modify_question_ids( $question_ids ) {
 	$prepared_query = call_user_func_array( array( $wpdb, 'prepare' ), $query_args );
 	$quiz_ids       = $wpdb->get_col( $prepared_query );
 
-	$current_user = get_current_user_id();
+	if ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) ) {
+		return false;
+	}
+
 	foreach ( $quiz_ids as $quiz_id ) {
-		$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'quiz_id' AND meta_value = %d LIMIT 1", intval( $quiz_id ) ) );
-		// If quiz mapping is missing, only allow elevated users.
-		if ( empty( $post_id ) && ! current_user_can( 'edit_others_qsm_quizzes' ) ) {
+		// Ownership is resolved centrally: deriving it here from the 'quiz_id'
+		// post meta would reintroduce the forgeable mapping the helper avoids.
+		if ( ! qsm_current_user_can_edit_quiz( intval( $quiz_id ) ) ) {
 			return false;
-		}
-
-		if ( ! empty( $post_id ) ) {
-			$post_author = intval( get_post_field( 'post_author', $post_id, true ) );
-			$owns_quiz   = ( $post_author === $current_user );
-
-			if ( ( ! current_user_can( 'edit_qsm_quiz', $post_id ) || ! $owns_quiz ) && ! current_user_can( 'edit_others_qsm_quizzes' ) ) {
-				return false;
-			}
 		}
 	}
 
@@ -1173,17 +1167,13 @@ function qsm_ajax_save_pages() {
 	}
 
 	global $mlwQuizMasterNext;
-	global $wpdb;
 	$json    = array(
 		'status' => 'error',
 	);
 	$quiz_id = isset( $_POST['quiz_id'] ) ? intval( $_POST['quiz_id'] ) : 0;
 
-	// Map quiz to its post and enforce edit capabilities.
-	$post_id    = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'quiz_id' AND meta_value = %d LIMIT 1", $quiz_id ) );
-	$post_author = get_post_field( 'post_author', $post_id, true );
-
-	if ( empty( $post_id ) || ( ( ! current_user_can( 'edit_qsm_quiz', $post_id ) || intval( $post_author ) !== get_current_user_id() ) && ! current_user_can( 'edit_others_qsm_quizzes' ) ) ) {
+	// Enforce edit permission through the central ownership helper.
+	if ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) || ! qsm_current_user_can_edit_quiz( $quiz_id ) ) {
 		wp_die( esc_html__( 'You are not allowed to edit this quiz, You need higher permission!', 'quiz-master-next' ) );
 	}
 
@@ -1241,7 +1231,7 @@ add_action( 'wp_ajax_qsm_save_default_question_settings', 'qsm_ajax_save_default
  * @since 11.2.3
  */
 function qsm_ajax_save_default_question_settings() {
-	global $mlwQuizMasterNext, $wpdb;
+	global $mlwQuizMasterNext;
 
 	$json    = array( 'status' => 'error' );
 	$quiz_id = isset( $_POST['quiz_id'] ) ? intval( $_POST['quiz_id'] ) : 0;
@@ -1250,11 +1240,8 @@ function qsm_ajax_save_default_question_settings() {
 		wp_send_json( $json );
 	}
 
-	// Map quiz to its post and enforce edit capabilities (mirrors qsm_ajax_save_pages).
-	$post_id     = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'quiz_id' AND meta_value = %d LIMIT 1", $quiz_id ) );
-	$post_author = get_post_field( 'post_author', $post_id, true );
-
-	if ( empty( $post_id ) || ( ( ! current_user_can( 'edit_qsm_quiz', $post_id ) || intval( $post_author ) !== get_current_user_id() ) && ! current_user_can( 'edit_others_qsm_quizzes' ) ) ) {
+	// Enforce edit permission through the central ownership helper (mirrors qsm_ajax_save_pages).
+	if ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) || ! qsm_current_user_can_edit_quiz( $quiz_id ) ) {
 		wp_send_json( $json );
 	}
 

--- a/php/admin/question-bank-page.php
+++ b/php/admin/question-bank-page.php
@@ -24,7 +24,10 @@ function qsm_get_question_bank_page_data() {
 
 	global $wpdb, $mlwQuizMasterNext;
 
-	$quiz_results = $wpdb->get_results( 'SELECT quiz_id, quiz_name FROM ' . $wpdb->prefix . 'mlw_quizzes WHERE deleted = 0 ORDER BY quiz_name ASC' );
+	// Scope the Question Bank listing to the quizzes the current user may edit.
+	// Users with edit_others_qsm_quizzes get the unfiltered list ('' access sql).
+	$qb_access    = function_exists( 'qsm_quiz_access_sql' ) ? qsm_quiz_access_sql() : '';
+	$quiz_results = $wpdb->get_results( 'SELECT quiz_id, quiz_name FROM ' . $wpdb->prefix . 'mlw_quizzes WHERE deleted = 0' . $qb_access . ' ORDER BY quiz_name ASC' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $qb_access is built from intval()ed ids in qsm_quiz_access_sql()
 	$quizzes      = array();
 	if ( ! empty( $quiz_results ) ) {
 		foreach ( $quiz_results as $quiz ) {
@@ -34,7 +37,7 @@ function qsm_get_question_bank_page_data() {
 			);
 		}
 	}
-	$quiz_ids_from_questions_table = $wpdb->get_results( 'SELECT DISTINCT quiz_id FROM ' . $wpdb->prefix . 'mlw_questions WHERE deleted = 0 ORDER BY quiz_id ASC' );
+	$quiz_ids_from_questions_table = $wpdb->get_results( 'SELECT DISTINCT quiz_id FROM ' . $wpdb->prefix . 'mlw_questions WHERE deleted = 0' . $qb_access . ' ORDER BY quiz_id ASC' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $qb_access is built from intval()ed ids in qsm_quiz_access_sql()
 
 	$question_categories = $wpdb->get_results( 'SELECT DISTINCT category FROM ' . $wpdb->prefix . 'mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 ORDER BY category ASC', 'ARRAY_A' );
 	$enabled              = get_option( 'qsm_multiple_category_enabled' );
@@ -950,6 +953,19 @@ function qsm_question_bank_import() {
 
 	$raw_quiz = isset( $_POST['bulk_quiz'] ) ? sanitize_text_field( wp_unslash( $_POST['bulk_quiz'] ) ) : '';
 	$quiz_id  = absint( $raw_quiz );
+
+	// IDOR (CWE-639, same class as CVE-2026-14825): edit_qsm_quizzes is a flat
+	// capability every role holds, so without a per-quiz ownership check a
+	// Contributor could bulk-import questions into another author's quiz. Gate
+	// the target quiz with the same helper the REST write routes use.
+	if ( $quiz_id && ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) || ! qsm_current_user_can_edit_quiz( $quiz_id ) ) ) {
+		wp_send_json_error(
+			array(
+				'message' => __( 'You are not allowed to import questions into this quiz.', 'quiz-master-next' ),
+			),
+			403
+		);
+	}
 	$file_details = $_FILES['bulk_csv']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 	$max_size     = wp_max_upload_size();
 	if ( ! empty( $file_details['size'] ) && $file_details['size'] > $max_size ) {

--- a/php/admin/quiz-options-page.php
+++ b/php/admin/quiz-options-page.php
@@ -19,13 +19,13 @@ function qsm_generate_quiz_options() {
 	global $wpdb;
 	global $mlwQuizMasterNext;
 	$quiz_id = isset( $_GET['quiz_id'] ) ? intval( $_GET['quiz_id'] ) : 0;
-	$quiz_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'quiz_id' AND meta_value = %d", $quiz_id ) );
-	$post_author = get_post_field( 'post_author', $quiz_post_id, true );
 	//user role addon is active
 	apply_filters( 'qsm_user_role_permission_page', true );
 
-	// Check if the current user has the capability to edit the quiz.
-	if ( ( ! current_user_can( 'edit_qsm_quiz', $quiz_post_id ) || intval($post_author) != get_current_user_id()) && ! current_user_can( 'edit_others_qsm_quizzes' ) ) {
+	// Check if the current user has the capability to edit the quiz. Ownership
+	// is resolved centrally so this screen cannot be reached through a forged
+	// 'quiz_id' post meta mapping.
+	if ( ! function_exists( 'qsm_current_user_can_edit_quiz' ) || ! qsm_current_user_can_edit_quiz( $quiz_id ) ) {
 		wp_die( 'You are not allowed to edit this quiz, You need higher permission!' );
 		return;
 	}

--- a/php/classes/class-qsm-install.php
+++ b/php/classes/class-qsm-install.php
@@ -1738,101 +1738,6 @@ class QSM_Install {
     }
 
 	/**
-	 * Records an owner for quizzes created before the quiz_author_id column.
-	 *
-	 * quiz_author_id was added in 7.3.8 with no backfill, so older quizzes hold
-	 * 0. Ownership for those has to fall back to the author of the post
-	 * carrying the 'quiz_id' meta -- a mapping any user who can edit a post
-	 * could forge, which is precisely what qsm_current_user_can_edit_quiz()
-	 * avoids everywhere else. Copying the author onto the plugin's own column
-	 * once retires that fallback instead of leaving it load-bearing forever.
-	 *
-	 * A quiz is backfilled only when its candidate posts AGREE on one author.
-	 * Picking a "best" post among disagreeing ones would let a forged mapping
-	 * be written permanently onto the very column the rest of the fix treats as
-	 * authoritative, which is worse than the fallback it replaces:
-	 * quiz_author_id also drives the admin quiz list, so a wrong value hands
-	 * the quiz over rather than merely failing to protect it. Where the
-	 * candidates disagree the quiz is left alone and keeps the runtime
-	 * fallback.
-	 *
-	 * A candidate must carry the shortcode QMNQuizCreator writes into the
-	 * genuine post's content; a post that merely holds the meta key does not.
-	 * Requiring it means a quiz whose genuine post is gone is left on the
-	 * fallback rather than migrated on the word of whatever post remains. That
-	 * is no worse than today for those quizzes, and it is the difference
-	 * between failing to improve them and permanently recording the wrong
-	 * owner.
-	 *
-	 * Runs once, guarded by an option, and never overwrites a recorded author.
-	 *
-	 * @since 11.2.4
-	 * @return void
-	 */
-	private function backfill_quiz_author_ids() {
-		global $wpdb;
-
-		if ( get_option( 'qsm_quiz_author_backfilled' ) ) {
-			return;
-		}
-
-		$quizzes_table = $wpdb->prefix . 'mlw_quizzes';
-		if ( $wpdb->get_var( "SHOW TABLES LIKE '{$quizzes_table}'" ) !== $quizzes_table ) {
-			return;
-		}
-
-		// One pass over every unowned quiz's candidate posts: a per-quiz query
-		// would put thousands of round trips into a single upgrade request on a
-		// large site.
-		$candidates = $wpdb->get_results(
-			"SELECT pm.meta_value AS quiz_id, p.post_author, p.post_content
-			FROM {$quizzes_table} q
-			INNER JOIN {$wpdb->postmeta} pm ON pm.meta_key = 'quiz_id' AND pm.meta_value = q.quiz_id
-			INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
-			WHERE ( q.quiz_author_id IS NULL OR CAST( q.quiz_author_id AS UNSIGNED ) = 0 )
-				AND p.post_type = 'qsm_quiz' AND p.post_status != 'trash'"
-		);
-
-		// Keep only the posts QMNQuizCreator actually generated, then count the
-		// survivors per quiz so contested mappings can be dropped.
-		$genuine = array();
-		foreach ( (array) $candidates as $candidate ) {
-			$quiz_id = intval( $candidate->quiz_id );
-			if ( 0 === $quiz_id ) {
-				continue;
-			}
-			$shortcode = '[mlw_quizmaster quiz=' . $quiz_id . ']';
-			if ( false === strpos( (string) $candidate->post_content, $shortcode ) ) {
-				continue;
-			}
-			if ( ! isset( $genuine[ $quiz_id ] ) ) {
-				$genuine[ $quiz_id ] = array();
-			}
-			$genuine[ $quiz_id ][] = intval( $candidate->post_author );
-		}
-
-		foreach ( $genuine as $quiz_id => $authors ) {
-			$authors = array_unique( $authors );
-			// More than one genuine post, or none: leave it to the runtime check.
-			if ( 1 !== count( $authors ) ) {
-				continue;
-			}
-			$author = intval( reset( $authors ) );
-			if ( $author > 0 ) {
-				$wpdb->update(
-					$quizzes_table,
-					array( 'quiz_author_id' => $author ),
-					array( 'quiz_id' => $quiz_id ),
-					array( '%d' ),
-					array( '%d' )
-				);
-			}
-		}
-
-		update_option( 'qsm_quiz_author_backfilled', 1 );
-	}
-
-	/**
 	 * Updates the plugin
 	 *
 	 * @since 4.7.1
@@ -2384,9 +2289,6 @@ class QSM_Install {
 			if ( 0 === $results_count ) {
 				update_option( 'qsm_migration_results_processed', 1 );
 			}
-
-			// Update 11.2.4 - record an owner for quizzes that predate quiz_author_id.
-			$this->backfill_quiz_author_ids();
 
 			// Update QSM versoin at last
 			update_option( 'mlw_quiz_master_version', $data );

--- a/php/classes/class-qsm-install.php
+++ b/php/classes/class-qsm-install.php
@@ -1738,6 +1738,101 @@ class QSM_Install {
     }
 
 	/**
+	 * Records an owner for quizzes created before the quiz_author_id column.
+	 *
+	 * quiz_author_id was added in 7.3.8 with no backfill, so older quizzes hold
+	 * 0. Ownership for those has to fall back to the author of the post
+	 * carrying the 'quiz_id' meta -- a mapping any user who can edit a post
+	 * could forge, which is precisely what qsm_current_user_can_edit_quiz()
+	 * avoids everywhere else. Copying the author onto the plugin's own column
+	 * once retires that fallback instead of leaving it load-bearing forever.
+	 *
+	 * A quiz is backfilled only when its candidate posts AGREE on one author.
+	 * Picking a "best" post among disagreeing ones would let a forged mapping
+	 * be written permanently onto the very column the rest of the fix treats as
+	 * authoritative, which is worse than the fallback it replaces:
+	 * quiz_author_id also drives the admin quiz list, so a wrong value hands
+	 * the quiz over rather than merely failing to protect it. Where the
+	 * candidates disagree the quiz is left alone and keeps the runtime
+	 * fallback.
+	 *
+	 * A candidate must carry the shortcode QMNQuizCreator writes into the
+	 * genuine post's content; a post that merely holds the meta key does not.
+	 * Requiring it means a quiz whose genuine post is gone is left on the
+	 * fallback rather than migrated on the word of whatever post remains. That
+	 * is no worse than today for those quizzes, and it is the difference
+	 * between failing to improve them and permanently recording the wrong
+	 * owner.
+	 *
+	 * Runs once, guarded by an option, and never overwrites a recorded author.
+	 *
+	 * @since 11.2.4
+	 * @return void
+	 */
+	private function backfill_quiz_author_ids() {
+		global $wpdb;
+
+		if ( get_option( 'qsm_quiz_author_backfilled' ) ) {
+			return;
+		}
+
+		$quizzes_table = $wpdb->prefix . 'mlw_quizzes';
+		if ( $wpdb->get_var( "SHOW TABLES LIKE '{$quizzes_table}'" ) !== $quizzes_table ) {
+			return;
+		}
+
+		// One pass over every unowned quiz's candidate posts: a per-quiz query
+		// would put thousands of round trips into a single upgrade request on a
+		// large site.
+		$candidates = $wpdb->get_results(
+			"SELECT pm.meta_value AS quiz_id, p.post_author, p.post_content
+			FROM {$quizzes_table} q
+			INNER JOIN {$wpdb->postmeta} pm ON pm.meta_key = 'quiz_id' AND pm.meta_value = q.quiz_id
+			INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+			WHERE ( q.quiz_author_id IS NULL OR CAST( q.quiz_author_id AS UNSIGNED ) = 0 )
+				AND p.post_type = 'qsm_quiz' AND p.post_status != 'trash'"
+		);
+
+		// Keep only the posts QMNQuizCreator actually generated, then count the
+		// survivors per quiz so contested mappings can be dropped.
+		$genuine = array();
+		foreach ( (array) $candidates as $candidate ) {
+			$quiz_id = intval( $candidate->quiz_id );
+			if ( 0 === $quiz_id ) {
+				continue;
+			}
+			$shortcode = '[mlw_quizmaster quiz=' . $quiz_id . ']';
+			if ( false === strpos( (string) $candidate->post_content, $shortcode ) ) {
+				continue;
+			}
+			if ( ! isset( $genuine[ $quiz_id ] ) ) {
+				$genuine[ $quiz_id ] = array();
+			}
+			$genuine[ $quiz_id ][] = intval( $candidate->post_author );
+		}
+
+		foreach ( $genuine as $quiz_id => $authors ) {
+			$authors = array_unique( $authors );
+			// More than one genuine post, or none: leave it to the runtime check.
+			if ( 1 !== count( $authors ) ) {
+				continue;
+			}
+			$author = intval( reset( $authors ) );
+			if ( $author > 0 ) {
+				$wpdb->update(
+					$quizzes_table,
+					array( 'quiz_author_id' => $author ),
+					array( 'quiz_id' => $quiz_id ),
+					array( '%d' ),
+					array( '%d' )
+				);
+			}
+		}
+
+		update_option( 'qsm_quiz_author_backfilled', 1 );
+	}
+
+	/**
 	 * Updates the plugin
 	 *
 	 * @since 4.7.1
@@ -2289,6 +2384,10 @@ class QSM_Install {
 			if ( 0 === $results_count ) {
 				update_option( 'qsm_migration_results_processed', 1 );
 			}
+
+			// Update 11.2.4 - record an owner for quizzes that predate quiz_author_id.
+			$this->backfill_quiz_author_ids();
+
 			// Update QSM versoin at last
 			update_option( 'mlw_quiz_master_version', $data );
 		}

--- a/php/classes/class-qsm-install.php
+++ b/php/classes/class-qsm-install.php
@@ -2289,7 +2289,6 @@ class QSM_Install {
 			if ( 0 === $results_count ) {
 				update_option( 'qsm_migration_results_processed', 1 );
 			}
-
 			// Update QSM versoin at last
 			update_option( 'mlw_quiz_master_version', $data );
 		}

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -151,8 +151,16 @@ function qsm_register_rest_routes() {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => 'qsm_rest_get_bank_questions',
-				'permission_callback' => function () {
-					return current_user_can( 'edit_qsm_quizzes' );
+				'permission_callback' => function ( WP_REST_Request $request ) {
+					// IDOR (CWE-639): gate the specific quiz named by quizID, the
+					// same per-quiz ownership check the sibling routes enforce.
+					// The unscoped bank (no quizID) is additionally constrained to
+					// the caller's own quizzes inside the handler via
+					// qsm_quiz_access_sql(), so neither a foreign quizID nor an
+					// unfiltered request can disclose another author's questions.
+					return current_user_can( 'edit_qsm_quizzes' )
+						&& ( empty( $request->get_param( 'quizID' ) )
+							|| qsm_current_user_can_edit_quiz( $request->get_param( 'quizID' ) ) );
 				},
 			)
 		);

--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -936,6 +936,17 @@ function qsm_verify_rest_user_nonce( $id, $user_id, $rest_nonce ) {
 /**
  * Resolve a quiz_id to its backing post_id.
  *
+ * The 'quiz_id' meta key is not protected (no leading underscore), so any user
+ * who can edit a post could otherwise attach it to a post of their own and be
+ * mistaken for the quiz's owner. The lookup is therefore constrained to
+ * genuine, non-trashed qsm_quiz posts -- the only shape QMNQuizCreator ever
+ * creates -- and ordered so that the result is deterministic rather than
+ * whatever row the engine happens to yield first.
+ *
+ * This narrows the forgery surface but does not close it on its own; ownership
+ * decisions must go through qsm_current_user_can_edit_quiz(), which prefers the
+ * plugin's own mlw_quizzes.quiz_author_id column.
+ *
  * @param int $quiz_id The mlw_quizzes.quiz_id value.
  * @return int|false Post ID or false if not found.
  */
@@ -947,11 +958,46 @@ function qsm_get_post_id_for_quiz( $quiz_id ) {
 	}
 	$post_id = $wpdb->get_var(
 		$wpdb->prepare(
-			"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = 'quiz_id' AND meta_value = %d LIMIT 1",
+			"SELECT pm.post_id FROM {$wpdb->postmeta} pm
+			INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+			WHERE pm.meta_key = 'quiz_id' AND pm.meta_value = %d
+				AND p.post_type = 'qsm_quiz' AND p.post_status != 'trash'
+			ORDER BY p.ID ASC LIMIT 1",
 			$quiz_id
 		)
 	);
 	return $post_id ? intval( $post_id ) : false;
+}
+
+/**
+ * Returns the author recorded against a quiz by the plugin itself.
+ *
+ * mlw_quizzes.quiz_author_id is written by QMNQuizCreator when a quiz is
+ * created or duplicated and is not reachable through the generic WordPress
+ * meta APIs, which makes it the trustworthy ownership signal. It is also what
+ * QMNPluginHelper::get_quizzes() already filters the admin quiz list on.
+ *
+ * The column was added in 7.3.8 with no backfill, so quizzes created before
+ * that upgrade hold an empty value. Callers must treat 0 as "not recorded"
+ * rather than "owned by nobody".
+ *
+ * @since 11.2.4
+ * @param int $quiz_id The mlw_quizzes.quiz_id value.
+ * @return int User ID, or 0 when the quiz is unknown or predates the column.
+ */
+function qsm_get_quiz_author_id( $quiz_id ) {
+	global $wpdb;
+	$quiz_id = intval( $quiz_id );
+	if ( 0 === $quiz_id ) {
+		return 0;
+	}
+	$author_id = $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT quiz_author_id FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d LIMIT 1",
+			$quiz_id
+		)
+	);
+	return intval( $author_id );
 }
 
 /**
@@ -970,6 +1016,14 @@ function qsm_get_post_id_for_quiz( $quiz_id ) {
  * Only edit_others_qsm_quizzes (editor/administrator) may act on a quiz the
  * current user does not own.
  *
+ * Ownership itself is read from mlw_quizzes.quiz_author_id where the plugin
+ * recorded it. Deriving it from the 'quiz_id' post meta instead is unsafe: the
+ * key is unprotected, so a user who can edit any post could attach another
+ * author's quiz id to it and be treated as that quiz's owner. The post-author
+ * path survives only as a fallback for quizzes created before quiz_author_id
+ * existed (7.3.8), where denying outright would lock legitimate owners out of
+ * their own quizzes.
+ *
  * @since 11.2.4
  * @param int $quiz_id The mlw_quizzes.quiz_id value.
  * @return bool
@@ -984,25 +1038,43 @@ function qsm_current_user_can_edit_quiz( $quiz_id ) {
 		return true;
 	}
 
+	if ( ! current_user_can( 'edit_qsm_quizzes' ) ) {
+		return false;
+	}
+
+	$current_user = get_current_user_id();
+
+	// Preferred signal: the author the plugin itself recorded. Not writable
+	// through the WordPress meta APIs, so it cannot be forged by a Contributor.
+	$quiz_author = qsm_get_quiz_author_id( $quiz_id );
+	if ( $quiz_author > 0 ) {
+		return $current_user === $quiz_author;
+	}
+
+	// Legacy quiz (pre-7.3.8, no recorded author): fall back to the author of
+	// the backing qsm_quiz post.
 	$post_id = qsm_get_post_id_for_quiz( $quiz_id );
 	if ( ! $post_id ) {
-		// No backing post means ownership cannot be established: fail closed.
+		// Ownership cannot be established: fail closed.
 		return false;
 	}
 
 	$post_author = intval( get_post_field( 'post_author', $post_id ) );
 
-	return $post_author > 0
-		&& get_current_user_id() === $post_author
-		&& current_user_can( 'edit_qsm_quizzes' );
+	return $post_author > 0 && $current_user === $post_author;
 }
 
 /**
  * Returns the ids of every quiz the current user owns.
  *
- * Resolved in one query so a listing can be scoped in SQL instead of one
- * ownership lookup per row. Callers must handle the edit_others_qsm_quizzes
- * case themselves: this only ever reports the user's own quizzes.
+ * Resolved in bulk so a listing can be scoped in SQL instead of one ownership
+ * lookup per row. Callers must handle the edit_others_qsm_quizzes case
+ * themselves: this only ever reports the user's own quizzes.
+ *
+ * Mirrors qsm_current_user_can_edit_quiz() exactly -- quiz_author_id where the
+ * plugin recorded it, the backing qsm_quiz post's author only for quizzes that
+ * predate the column. Keeping the two in step matters: a listing that is more
+ * generous than the per-quiz gate is the same disclosure by another route.
  *
  * @since 11.2.4
  * @return array Quiz ids (int), empty when the user owns none.
@@ -1014,14 +1086,26 @@ function qsm_get_editable_quiz_ids() {
 
 	global $wpdb;
 
-	// Mirrors qsm_get_post_id_for_quiz(): a quiz's owner is the author of the
-	// post carrying its 'quiz_id' meta.
+	$current_user  = get_current_user_id();
+	$quizzes_table = $wpdb->prefix . 'mlw_quizzes';
+
+	// Two ownership sources in one round trip: the recorded author, and -- for
+	// legacy quizzes only -- the author of the backing qsm_quiz post. Deliberately
+	// not memoised: qsm_quiz_access_sql() calls this several times per request,
+	// but a stale answer in an authorization helper is a worse bug than the
+	// query it saves.
 	$quiz_ids = $wpdb->get_col(
 		$wpdb->prepare(
-			"SELECT pm.meta_value FROM {$wpdb->postmeta} pm
+			"SELECT quiz_id FROM {$quizzes_table} WHERE quiz_author_id = %d
+			UNION
+			SELECT q.quiz_id FROM {$quizzes_table} q
+			INNER JOIN {$wpdb->postmeta} pm ON pm.meta_key = 'quiz_id' AND pm.meta_value = q.quiz_id
 			INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
-			WHERE pm.meta_key = 'quiz_id' AND p.post_author = %d",
-			get_current_user_id()
+			WHERE ( q.quiz_author_id IS NULL OR CAST( q.quiz_author_id AS UNSIGNED ) = 0 )
+				AND p.post_type = 'qsm_quiz' AND p.post_status != 'trash'
+				AND p.post_author = %d",
+			$current_user,
+			$current_user
 		)
 	);
 


### PR DESCRIPTION
## ⚠ This PR now fixes a formally-reported CVE (not just hardening)

On 2026-08-07 a **third researcher, Shikhali Jamalzade**, reported the **`bank_questions` IDOR** (CWE-639) to **wp.org + Patchstack** against 11.2.3 — the exact endpoint this PR already scopes. So #3217 is no longer optional follow-up: it carries its own 30-day remediation clock.

> **Report:** `GET /wp-json/quiz-survey-master/v1/bank_questions/{id}?quizID={id}` gated only on `current_user_can('edit_qsm_quizzes')` (a cap the plugin grants Contributors), with no per-quiz ownership check → any Contributor reads any author's question bank (answer keys, hints, comments). Reproduced live on 11.2.3: HTTP 200 + full disclosure.

**Fixed here two ways (belt-and-suspenders):**
1. `permission_callback` now enforces `qsm_current_user_can_edit_quiz(quizID)` (the reporter's suggested fix) → a foreign `quizID` is rejected **403**.
2. The handler's `qsm_quiz_access_sql()` result-set filter constrains the **unscoped** bank (no `quizID`) to the caller's own quizzes — the enumeration case the suggested `permission_callback` alone would miss.

**Verified live (WP 6.9.4 / QSM 11.2.3):** Contributor→foreign `quizID` now **403** (was 200 + disclosure); no-`quizID` → 200 with no foreign rows; own quiz → 200; **admin/editor unaffected**.

---

## The rest of this PR — cross-quiz ownership hardening (stacked on #3216)

Everything else here is defense-in-depth beyond the two CVEs #3216 fixes. Kept separate so the reporter's fix ships tight.

**Base:** `fix/qsm-cve-2026-14825-14826-ownership-helper` (#3216). Retarget to `dev` once #3216 merges.

### 1. Ownership from an unforgeable source (`quiz_author_id`)
#3216 compares the current user to `get_post_field('post_author', $post_id)`, where `$post_id` comes from the **`quiz_id` post meta** — an unprotected key a post-editor could forge to be mistaken for a quiz's owner. This reads ownership from `mlw_quizzes.quiz_author_id` (not writable via the WP meta APIs), post-author kept only as a pre-7.3.8 fallback, and marks the `quiz_id` meta `is_protected_meta`.

### 2. Result-set scoping for the multi-quiz reads
- **`GET /questions/`** unscoped listing — `qsm_filter_questions_by_quiz_access()` drops foreign rows.
- **`GET /bank_questions/`** — the reported endpoint; `qsm_quiz_access_sql()` + `esc_like()` on the `quizID` filter (`%`/`1%` can't widen it), plus the new ownership gate above.
- Scoped `GET /questions/?quizID=`, `GET /quizzes/{id}/categories` routed through the helper.

### 3. Admin surfaces through the central helper
`quiz-options-page.php` and the questions-tab AJAX handlers (`qsm_ajax_save_pages`, `qsm_ajax_save_default_question_settings`, `qsm_user_can_modify_question_ids`) — replacing inlined forgeable `post_author` lookups.

**Files:** `php/rest-api.php`, `mlw_quizmaster2.php`, `php/admin/quiz-options-page.php`, `php/admin/options-page-questions-tab.php`.

> Do **not** auto-merge / auto-release — human-gated. Recommend shipping this alongside #3216 in the same release; the reported `bank_questions` IDOR is fixed only here.
Credit: **Shikhali Jamalzade** (bank_questions IDOR / CWE-639).
