### PR TITLE
Release: QSM 11.2.4

### DIFF
--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Quiz And Survey Master
  * Description: Easily and quickly add quizzes and surveys to your website.
- * Version: 11.2.3
+ * Version: 11.2.4
  * Author: ExpressTech
  * Author URI: https://quizandsurveymaster.com/
  * Plugin URI: https://expresstech.io/
@@ -47,7 +47,7 @@ class MLWQuizMasterNext {
 	 * @var string
 	 * @since 4.0.0
 	 */
-	public $version = '11.2.3';
+	public $version = '11.2.4';
 
 	/**
 	 * QSM Alert Manager Object

--- a/readme.txt
+++ b/readme.txt
@@ -118,14 +118,12 @@ Please report security bugs found in the source code of the Quiz And Survey Mast
 
 == Changelog ==
 = 11.2.4 (August 10, 2026) =
-* Security: Fixed a Contributor+ cross-quiz ownership bypass by deriving quiz ownership from the quiz author record instead of the forgeable "quiz_id" post meta.
-* Security: Fixed a Contributor+ cross-quiz information disclosure in the questions and question bank REST GET endpoints by enforcing a per-quiz ownership check.
-* Security: Fixed a Contributor+ cross-quiz access issue in the Question Bank quiz picker and CSV bulk import by scoping them to the user's own quizzes.
-* Security: Added direct file access guards across plugin files and sanitized lazily loaded answer IDs.
-* Bug: Fixed a newly created quiz inheriting data from a previously deleted quiz that reused the same quiz ID.
-* Bug: Fixed question type names not being translated when importing questions in the Question Bank.
-* Bug: Fixed the quiz navigator jumping to the wrong page and question numbers on the new renderer.
-* Enhancement: Improved WordPress.org release compliance with packaging exclusions and Plugin Check guideline fixes.
+* Security: Fixed a Contributor+ ownership bypass by validating author records instead of post meta.
+* Security: Fixed a Contributor+ information disclosure issue in REST endpoints by enforcing per-quiz ownership checks
+* Security: Restricted the Question Bank picker and CSV import to quizzes owned by the current user
+* Security: Added direct file access protection and sanitized lazy-loaded answer IDs.
+* Bug: Fixed missing translations for question type names during Question Bank import.
+* Bug: Fixed quiz navigator jumping to incorrect pages and question numbers in the new renderer.
 
 = 11.2.3 (July 29, 2026) =
 * Feature: Added default settings for newly created questions.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: quiz, survey, quiz maker, survey maker, exam
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 5.4
-Stable tag: 11.2.3
+Stable tag: 11.2.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -117,6 +117,16 @@ Please report security bugs found in the source code of the Quiz And Survey Mast
 18. Database and submission records
 
 == Changelog ==
+= 11.2.4 (August 10, 2026) =
+* Security: Fixed a Contributor+ cross-quiz ownership bypass by deriving quiz ownership from the quiz author record instead of the forgeable "quiz_id" post meta.
+* Security: Fixed a Contributor+ cross-quiz information disclosure in the questions and question bank REST GET endpoints by enforcing a per-quiz ownership check.
+* Security: Fixed a Contributor+ cross-quiz access issue in the Question Bank quiz picker and CSV bulk import by scoping them to the user's own quizzes.
+* Security: Added direct file access guards across plugin files and sanitized lazily loaded answer IDs.
+* Bug: Fixed a newly created quiz inheriting data from a previously deleted quiz that reused the same quiz ID.
+* Bug: Fixed question type names not being translated when importing questions in the Question Bank.
+* Bug: Fixed the quiz navigator jumping to the wrong page and question numbers on the new renderer.
+* Enhancement: Improved WordPress.org release compliance with packaging exclusions and Plugin Check guideline fixes.
+
 = 11.2.3 (July 29, 2026) =
 * Feature: Added default settings for newly created questions.
 * Bug: Resolved the processing message display configuration issue.


### PR DESCRIPTION
Release commit for **QSM 11.2.4** — everything merged into `dev` since 11.2.3 (PR #3200, 29 Jul 2026). Bumps the plugin header `Version`, the `MLWQuizMasterNext::$version` property, and `readme.txt` `Stable tag`, and adds the 11.2.4 changelog block.

`dev-zubair` was fast-forwarded to `dev` first, so this PR is exactly one commit of diff (2 files).

## Version

| | From | To |
| --- | --- | --- |
| `mlw_quizmaster2.php` plugin header | 11.2.3 | **11.2.4** |
| `MLWQuizMasterNext::$version` | 11.2.3 | **11.2.4** |
| `readme.txt` Stable tag | 11.2.3 | **11.2.4** |

Patch bump: no new user-facing feature landed — the release is security hardening, bug fixes, and wp.org compliance. The already-merged code documents itself as `@since 11.2.4` (`qsm_protect_quiz_meta()`), so this matches what's in the tree.

## What's in 11.2.4

### Security — quiz ownership hardening (#3216, #3219)
Follow-up hardening in the CVE-2026-14825 / CVE-2026-14826 class. Not new advisories; these close the remaining paths.
- `qsm_current_user_can_edit_quiz()` now derives ownership from `mlw_quizzes.quiz_author_id` rather than the `quiz_id` post meta, which a Contributor could set on their own draft to impersonate another author's quiz. The `quiz_id` meta key is also marked protected via `is_protected_meta`, so the classic Custom Fields metabox refuses it.
- The `quiz_author_id` backfill was dropped — it could record a forged owner.
- Per-quiz ownership enforced on REST `GET /questions/` and `GET /bank_questions/` (including the `permission_callback`).
- Question Bank quiz picker scoped to owned quizzes, and the CSV bulk-import target gated.

### Security — Plugin Check hardening (#3203)
- ABSPATH direct-file-access guards added across plugin files; lazily loaded answer IDs sanitized.

### Bugs
- Newly created quiz inheriting settings/data from a previously deleted quiz that reused the same quiz ID (#3218)
- Question type names not translated when importing questions in the Question Bank — #3213 ([CU-86d3tyduw](https://app.clickup.com/t/1868024/86d3tyduw))
- Quiz navigator jumping to the wrong page / wrong question numbers on the new renderer — #3202, #3214 ([CU-86d3tyduw](https://app.clickup.com/t/1868024/86d3tyduw))

### wp.org release compliance (#3204, #3207)
- `.distignore` packaging exclusions, `index.php` guards, `ISSUE_TEMPLATE.md` relocated to `.github/`, plugin-header `License`/`Requires at least`/`Requires PHP` aligned with `readme.txt`, translators-comment positions, `.env.sample` excluded.

## Notes for review

- **#3209 was reverted by #3211** ("Show-question-numbers drift after navigator jump to lazy pages"), so that fix is deliberately **not** in the changelog. The navigator entry covers #3202 and #3214 only.
- No CVE IDs are claimed for the ownership work in this release — it's hardening of the class already disclosed in 11.2.2, and inventing new IDs in the changelog would be wrong. Add them if advisories get assigned before release.
- No PHP available in this environment, so nothing was linted; the diff is version strings and readme text only.

Agent OS session: https://ai.expresstech.io/#/sessions/aos-ses_532b3beea62f56f5
