### PR TITLE
Security: fix unauthenticated unthrottled login brute-force via qsm_ajax_login (CWE-307)

### DIFF
--- a/js/qsm-common.js
+++ b/js/qsm-common.js
@@ -61,7 +61,7 @@ jQuery(document).ready(function(){
 					// answer (rate limited, or a 2FA/lockout veto it cannot
 					// resolve). Submit the form so wp-login.php handles the login
 					// normally instead of dead-ending here.
-					if ( response && ( response.success || ( response.data && response.data.fallback ) ) ) {
+					if ( response?.success || response?.data?.fallback ) {
 						form.get(0).submit();
 						return;
 					}
@@ -71,7 +71,7 @@ jQuery(document).ready(function(){
 					// another tab — gets admin-ajax's bare "0" with HTTP 200.
 					// Anything we cannot read as an error goes to wp-login.php
 					// rather than leaving the submit button disabled forever.
-					if ( ! response || ! response.data || ! response.data.message ) {
+					if ( ! response?.data?.message ) {
 						form.get(0).submit();
 						return;
 					}

--- a/js/qsm-common.js
+++ b/js/qsm-common.js
@@ -58,13 +58,25 @@ jQuery(document).ready(function(){
 				},
 				success: function (response) {
 					// A "fallback" error means the pre-flight check declined to
-					// answer (rate limited). Submit the form so wp-login.php
-					// handles the login normally instead of dead-ending here.
-					if ( response.success || ( response.data && response.data.fallback ) ) {
+					// answer (rate limited, or a 2FA/lockout veto it cannot
+					// resolve). Submit the form so wp-login.php handles the login
+					// normally instead of dead-ending here.
+					if ( response && ( response.success || ( response.data && response.data.fallback ) ) ) {
 						form.get(0).submit();
-					} else {
-						qsmShowLoginError(response.data.message);
+						return;
 					}
+
+					// Only nopriv is registered for this action, so an already
+					// logged-in caller — a cached logged-out page, or a login in
+					// another tab — gets admin-ajax's bare "0" with HTTP 200.
+					// Anything we cannot read as an error goes to wp-login.php
+					// rather than leaving the submit button disabled forever.
+					if ( ! response || ! response.data || ! response.data.message ) {
+						form.get(0).submit();
+						return;
+					}
+
+					qsmShowLoginError(response.data.message);
 				},
 				error: function () {
 					// Never block a legitimate login on a failed pre-flight check.

--- a/js/qsm-common.js
+++ b/js/qsm-common.js
@@ -57,11 +57,18 @@ jQuery(document).ready(function(){
 					nonce: nonce,
 				},
 				success: function (response) {
-					if ( response.success ) {
+					// A "fallback" error means the pre-flight check declined to
+					// answer (rate limited). Submit the form so wp-login.php
+					// handles the login normally instead of dead-ending here.
+					if ( response.success || ( response.data && response.data.fallback ) ) {
 						form.get(0).submit();
 					} else {
 						qsmShowLoginError(response.data.message);
 					}
+				},
+				error: function () {
+					// Never block a legitimate login on a failed pre-flight check.
+					form.get(0).submit();
 				}
 			});
 		}

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -262,8 +262,59 @@ class QMNQuizManager {
 	}
 
 	/**
+	 * Resolve the client IP used to throttle failed login pre-flight checks.
+	 *
+	 * Only REMOTE_ADDR is trusted. Proxy headers such as X-Forwarded-For are
+	 * attacker-supplied and would let a single client reset the counter at will,
+	 * so sites behind a reverse proxy must supply the real IP through the
+	 * `qsm_login_client_ip` filter instead.
+	 *
+	 * @since 11.2.5
+	 * @return string The client IP, or an empty string when it cannot be resolved.
+	 */
+	private function qsm_login_client_ip() {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+
+		/**
+		 * Filter the client IP used to throttle failed login pre-flight checks.
+		 *
+		 * @since 11.2.5
+		 * @param string $ip The IP resolved from REMOTE_ADDR.
+		 */
+		$ip = apply_filters( 'qsm_login_client_ip', $ip );
+
+		return is_string( $ip ) ? $ip : '';
+	}
+
+	/**
+	 * Transient key holding the failed pre-flight login count for a client IP.
+	 *
+	 * @since 11.2.5
+	 * @param  string $ip The client IP.
+	 * @return string The transient key, or an empty string when there is no IP to key on.
+	 */
+	private function qsm_login_attempts_key( $ip ) {
+		return '' === $ip ? '' : 'qsm_login_attempts_' . md5( $ip );
+	}
+
+	/**
 	 * @version 8.2.0
 	 * ajax login function
+	 *
+	 * This endpoint only pre-checks the submitted credentials so the quiz page can
+	 * show an inline error; the browser still submits the form to wp-login.php to
+	 * establish the session. Because it is reachable unauthenticated, it must not
+	 * become a credential oracle:
+	 *
+	 * - Authentication runs through wp_authenticate(), so the `authenticate` filter
+	 *   chain (login limiters, 2FA) can veto the attempt and `wp_login_failed`
+	 *   fires for plugins that count failures. Calling wp_check_password() directly
+	 *   bypassed all of that (CWE-307).
+	 * - Failures are throttled per client IP. Once the limit is reached the endpoint
+	 *   stops answering and tells the browser to submit the form to wp-login.php,
+	 *   which degrades to the normal WordPress login instead of denying service.
+	 *
+	 * @since 11.2.5 Routed through wp_authenticate() and rate limited.
 	 */
 	public function qsm_ajax_login() {
 		// Verify the nonce first.
@@ -283,14 +334,67 @@ class QMNQuizManager {
 			wp_send_json_error( array( 'message' => __( 'Please enter both a username and a password.', 'quiz-master-next' ) ) );
 		}
 
-		$user = get_user_by( 'login', $username );
+		/**
+		 * Filter how many failed pre-flight login checks a client IP may make
+		 * before this endpoint stops answering and defers to wp-login.php.
+		 *
+		 * @since 11.2.5
+		 * @param int $limit Maximum failures per window.
+		 */
+		$limit = (int) apply_filters( 'qsm_login_attempt_limit', 5 );
 
-		if ( ! $user ) {
-			$user = get_user_by( 'email', $username );
+		/**
+		 * Filter the window, in seconds, over which failed pre-flight login
+		 * checks are counted for a client IP.
+		 *
+		 * @since 11.2.5
+		 * @param int $window Window length in seconds.
+		 */
+		$window = (int) apply_filters( 'qsm_login_attempt_window', 15 * MINUTE_IN_SECONDS );
+
+		$ip       = $this->qsm_login_client_ip();
+		$key      = $this->qsm_login_attempts_key( $ip );
+		$attempts = '' === $key ? 0 : (int) get_transient( $key );
+
+		// Out of attempts: answer nothing about the credentials and let the form
+		// post to wp-login.php, where core and any login hardening still apply.
+		if ( $limit > 0 && $attempts >= $limit ) {
+			wp_send_json_error(
+				array(
+					'code'     => 'too_many_attempts',
+					'fallback' => true,
+					'message'  => __( 'Too many login attempts. Please wait a moment and try again.', 'quiz-master-next' ),
+				)
+			);
 		}
 
-		if ( ! $user || ! wp_check_password( $password, $user->user_pass, $user->ID ) ) {
-			wp_send_json_error( array( 'message' => __( 'Incorrect username or password! Please try again.', 'quiz-master-next' ) ) );
+		// wp_authenticate() runs the `authenticate` filter chain and fires
+		// `wp_login_failed`, so login limiters and 2FA plugins are honoured.
+		$user = wp_authenticate( $username, $password );
+
+		if ( is_wp_error( $user ) ) {
+			if ( '' !== $key ) {
+				set_transient( $key, $attempts + 1, $window );
+			}
+
+			// Credential errors always get the same message so this endpoint does
+			// not confirm whether an account exists. Errors raised by other
+			// plugins (lockouts, 2FA challenges) are passed through, since the
+			// user needs to see them to recover.
+			$generic_codes = array( 'invalid_username', 'invalid_email', 'incorrect_password', 'authentication_failed' );
+			$message       = in_array( $user->get_error_code(), $generic_codes, true )
+				? __( 'Incorrect username or password! Please try again.', 'quiz-master-next' )
+				: wp_kses_post( $user->get_error_message() );
+
+			if ( '' === trim( wp_strip_all_tags( $message ) ) ) {
+				$message = __( 'Incorrect username or password! Please try again.', 'quiz-master-next' );
+			}
+
+			wp_send_json_error( array( 'message' => $message ) );
+		}
+
+		if ( '' !== $key ) {
+			delete_transient( $key );
 		}
 
 		wp_send_json_success();

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -313,6 +313,9 @@ class QMNQuizManager {
 	 * - Failures are throttled per client IP. Once the limit is reached the endpoint
 	 *   stops answering and tells the browser to submit the form to wp-login.php,
 	 *   which degrades to the normal WordPress login instead of denying service.
+	 * - Only a plain wrong-credentials result is reported inline. Any other veto
+	 *   (2FA challenge, lockout) also defers to wp-login.php, which owns those
+	 *   flows and can actually complete them.
 	 *
 	 * @since 11.2.5 Routed through wp_authenticate() and rate limited.
 	 */
@@ -377,20 +380,27 @@ class QMNQuizManager {
 				set_transient( $key, $attempts + 1, $window );
 			}
 
-			// Credential errors always get the same message so this endpoint does
-			// not confirm whether an account exists. Errors raised by other
-			// plugins (lockouts, 2FA challenges) are passed through, since the
-			// user needs to see them to recover.
-			$generic_codes = array( 'invalid_username', 'invalid_email', 'incorrect_password', 'authentication_failed' );
-			$message       = in_array( $user->get_error_code(), $generic_codes, true )
-				? __( 'Incorrect username or password! Please try again.', 'quiz-master-next' )
-				: wp_kses_post( $user->get_error_message() );
+			// A plain wrong-credentials result is the one case this endpoint
+			// answers, and every such code gets the same message so it never
+			// confirms whether an account exists.
+			$credential_codes = array( 'invalid_username', 'invalid_email', 'incorrect_password', 'authentication_failed' );
 
-			if ( '' === trim( wp_strip_all_tags( $message ) ) ) {
-				$message = __( 'Incorrect username or password! Please try again.', 'quiz-master-next' );
+			if ( in_array( $user->get_error_code(), $credential_codes, true ) ) {
+				wp_send_json_error( array( 'message' => __( 'Incorrect username or password! Please try again.', 'quiz-master-next' ) ) );
 			}
 
-			wp_send_json_error( array( 'message' => $message ) );
+			// Anything else came from another plugin vetoing the attempt — a 2FA
+			// challenge, a lockout notice, a custom gate. Those flows are owned by
+			// wp-login.php (that is where the OTP field and the lockout screen
+			// live), so defer to it rather than dead-ending the user here on an
+			// error this form cannot resolve.
+			wp_send_json_error(
+				array(
+					'code'     => $user->get_error_code(),
+					'fallback' => true,
+					'message'  => __( 'Please complete your sign in.', 'quiz-master-next' ),
+				)
+			);
 		}
 
 		if ( '' !== $key ) {

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -338,13 +338,23 @@ class QMNQuizManager {
 		}
 
 		/**
-		 * Filter how many failed pre-flight login checks a client IP may make
-		 * before this endpoint stops answering and defers to wp-login.php.
+		 * Filter how many pre-flight login checks a client IP may make before this
+		 * endpoint stops answering and defers to wp-login.php.
+		 *
+		 * Successful checks count too, so this is deliberately generous: several
+		 * people can share one IP behind a school or office NAT, and exhausting the
+		 * budget only costs them the inline error message, never the ability to log
+		 * in. The number does not have to be brute-force-proof on its own — running
+		 * out sends the client to wp-login.php, which is not a credential oracle.
+		 *
+		 * A limit of 0 blocks every pre-flight check (the endpoint always defers to
+		 * wp-login.php). To switch the throttle off, filter it to a very high
+		 * number rather than to 0.
 		 *
 		 * @since 11.2.5
-		 * @param int $limit Maximum failures per window.
+		 * @param int $limit Maximum checks per window.
 		 */
-		$limit = (int) apply_filters( 'qsm_login_attempt_limit', 5 );
+		$limit = max( 0, (int) apply_filters( 'qsm_login_attempt_limit', 20 ) );
 
 		/**
 		 * Filter the window, in seconds, over which failed pre-flight login
@@ -361,7 +371,7 @@ class QMNQuizManager {
 
 		// Out of attempts: answer nothing about the credentials and let the form
 		// post to wp-login.php, where core and any login hardening still apply.
-		if ( $limit > 0 && $attempts >= $limit ) {
+		if ( $attempts >= $limit ) {
 			wp_send_json_error(
 				array(
 					'code'     => 'too_many_attempts',
@@ -371,15 +381,21 @@ class QMNQuizManager {
 			);
 		}
 
+		// Count the attempt BEFORE authenticating, and never clear the counter on
+		// success. Counting afterwards would leave the slow password hash inside
+		// the read-modify-write window, so a burst of concurrent requests would
+		// all read the same count and spend one attempt between them; clearing on
+		// success would let anyone holding a single valid account (their own, on
+		// any site with open registration) reset the counter between guesses.
+		if ( '' !== $key ) {
+			set_transient( $key, $attempts + 1, $window );
+		}
+
 		// wp_authenticate() runs the `authenticate` filter chain and fires
 		// `wp_login_failed`, so login limiters and 2FA plugins are honoured.
 		$user = wp_authenticate( $username, $password );
 
 		if ( is_wp_error( $user ) ) {
-			if ( '' !== $key ) {
-				set_transient( $key, $attempts + 1, $window );
-			}
-
 			// A plain wrong-credentials result is the one case this endpoint
 			// answers, and every such code gets the same message so it never
 			// confirms whether an account exists.
@@ -401,10 +417,6 @@ class QMNQuizManager {
 					'message'  => __( 'Please complete your sign in.', 'quiz-master-next' ),
 				)
 			);
-		}
-
-		if ( '' !== $key ) {
-			delete_transient( $key );
 		}
 
 		wp_send_json_success();


### PR DESCRIPTION
Fixes the externally-reported CWE-307 in `qsm_ajax_login` (ClickUp [86d41bh4w](https://app.clickup.com/t/1868024/86d41bh4w), reported by Jakub Kozub). **Confirmed present on `dev` @ b48b46dc (11.2.4).**

## What the endpoint actually is

`qsm_ajax_login` is a **pre-flight credential check**, not a login. `js/qsm-common.js` intercepts the `qsm-login-form` submit (the `wp_login_form()` rendered by `qmn_require_login_check` when a quiz has *Require login*), asks this endpoint "are these credentials right?", and only then lets the form POST to `wp-login.php`, which establishes the actual session. Its whole job is showing an inline error instead of bouncing the user to `wp-login.php`.

That framing matters: the endpoint never had to authenticate, but because it *answers the question*, it was a credential oracle.

## Root cause

Two independent facts combine:

1. **The nonce is not a barrier.** `qsm_get_login_nonce` is registered `wp_ajax_nopriv_`, so any anonymous client mints a valid `qsm_ajax_login_nonce` on demand. (Removing that endpoint would not help — a WP nonce for an anonymous user is uid `0` + empty session token, so it is effectively uniform across all anonymous visitors, and the quiz page itself ships one in `qmn_common_ajax_object.nonce`. The nonce is CSRF protection, and it cannot be anything else here.)

2. **`wp_check_password()` was called directly** (old line 292), bypassing `wp_authenticate()`/`wp_signon()`. So:
   - the `authenticate` filter chain never ran → login limiters and 2FA plugins could not veto the attempt;
   - `wp_login_failed` never fired → failure counters never incremented;
   - nothing in core or the plugin rate-limited it.

Net effect: unlimited, unlogged, unthrottled password guessing against any account, from an unauthenticated client — and it *bypasses the site's own login hardening*, which is the part that makes this worse than plain `wp-login.php`. Confirmed against the reporter's PoC path.

## The fix

**`php/classes/class-qmn-quiz-manager.php`**

- Replaced the manual `get_user_by()` + `wp_check_password()` pair with **`wp_authenticate( $username, $password )`**. This restores the whole hook chain: limiters/2FA get their `authenticate` veto, and `wp_login_failed` fires on every real failure. It also handles the username-or-email lookup natively, so the manual `get_user_by('email')` fallback is gone. (Side effect worth knowing: `wp_authenticate()` trims the password exactly as `wp-login.php` does, so a password with trailing whitespace no longer passes pre-flight and then fails at the real login.)
- Added a **per-IP throttle** (default 20 checks / 15 min, transient-backed) as defense-in-depth for sites running no security plugin. Filterable: `qsm_login_attempt_limit`, `qsm_login_attempt_window`, `qsm_login_client_ip`.
- **Only `REMOTE_ADDR` is trusted** for the client IP. `X-Forwarded-For` is attacker-supplied and would let one client reset its own counter every request; sites behind a reverse proxy supply the real IP via the `qsm_login_client_ip` filter.
- **No new enumeration surface.** The credential-error codes (`invalid_username`, `invalid_email`, `incorrect_password`, `authentication_failed`) all collapse to the same generic message, as before.
- **Only a plain wrong-credentials result is answered inline.** Any other `authenticate` veto — a 2FA challenge, a limiter lockout, a login-captcha plugin — defers to `wp-login.php`, which is where the OTP field and lockout screen actually live.

**`js/qsm-common.js`**

- When the endpoint declines to answer it returns `fallback: true` and the browser **submits the form to `wp-login.php` anyway**. This is deliberate: the throttle stops the endpoint from answering, but it must not lock a legitimate user (or everyone behind one NAT) out of logging in. Login degrades to standard WordPress instead of dead-ending.
- An AJAX transport failure, or any response the JS cannot parse as an error, now submits the form too, instead of leaving the submit button permanently disabled.

## Throttle design notes

Three details are load-bearing and easy to "simplify" back into bugs:

- **The attempt is counted *before* `wp_authenticate()`, not after.** Counting after leaves the slow password hash inside the read-modify-write window, so a burst of concurrent requests all read the same count and spend one attempt between them.
- **The counter is never cleared on success.** Clearing it would let anyone holding a single valid account — their own, on any site with open registration — reset the counter between guesses and loop indefinitely from one IP.
- **Successful checks count too**, which is why the default is 20 rather than 5: several people share one IP behind a school or office NAT. Exhausting the budget costs them the inline error message, never the ability to log in.

The counter is still a transient read-modify-write, so it is not atomic — a tightly concurrent burst can overshoot the limit. That is an accepted limit of the defense-in-depth layer, not of the fix: the actual repair is `wp_authenticate()` restoring the hook chain, and overshooting the throttle only lands the client on `wp-login.php`.

## Why not just delete the endpoint

That is the truly minimal fix and it removes the oracle outright — but it regresses the inline-error UX this endpoint was added for (`2696a9a3 added login failed message`, `6504a501 Fixed login problem with nonce validation issue`). Happy to take that route instead if the team prefers less surface over the UX.

## Scope note

`wp_check_password` appears exactly once in the plugin — this call site. The full unauthenticated AJAX surface is `qmn_process_quiz`, `qsm_load_page_questions`, `qsm_validate_result_submission`, `qsm_create_quiz_nonce`, `qsm_get_login_nonce`, `qsm_ajax_login`; the first four are quiz-taking endpoints that are public by design, and this was the only credential-handling one.

## Verification

- Confirmed the vulnerable code path on `dev` @ b48b46dc, including that the nonce is anonymously mintable and that the JS treats the response as a gate before the real login.
- **Not runtime-verified — this session has no PHP runtime**, so no `php -l` and no live WordPress exercise. Structural checks only: brace/paren/`<?php` delta against the base file is unchanged, and `node --check` passes on the JS.
- A local review pass found six issues on the first commit; all are reconciled in `61d8b8f5` / `c0a64e0c` (2FA dead-end, counter-reset bypass, count-after-auth race, unguarded `response.data.message`, zero-limit inversion, plugin-message enumeration).
- **Needs a live check before merge**, on a sandbox with *Require login* enabled on a quiz: (1) wrong password → inline error, no login; (2) correct password → logs in as before; (3) exceed the limit → response flips to `fallback`, form posts to `wp-login.php`, login still possible with the right password; (4) with a login-limiter plugin active, failures now register in its log; (5) with a 2FA or login-captcha plugin active, login still completes through `wp-login.php`; (6) hit the endpoint while already logged in → form submits rather than freezing.

## For the release commit

Suggested `readme.txt` changelog line (feature PRs here don't touch the changelog):

> * Security: Fixed an unauthenticated brute-force weakness in the quiz login form by routing authentication through WordPress and rate-limiting failed attempts.

---
Agentric session: https://ai.expresstech.io/#/sessions/aos-ses_7a66d247f21f0c66
