### PR TITLE
Fix cross-quiz authorization gaps in abilities API and lazy-load endpoint

### DIFF
--- a/php/classes/class-qsm-abilities.php
+++ b/php/classes/class-qsm-abilities.php
@@ -337,6 +337,16 @@ class QSM_Abilities {
 	public function execute_list_quizzes( $input ) {
 		global $mlwQuizMasterNext;
 
+		// Scope the listing to the caller's own quizzes. permission_edit_quizzes()
+		// only proves the flat edit_qsm_quizzes capability, which every role from
+		// Contributor up holds, so without this the ability enumerates every quiz
+		// on the site. Constrained in SQL rather than after the fetch so LIMIT and
+		// OFFSET still describe the rows actually returned.
+		$access_where = $this->quiz_access_where();
+		if ( false === $access_where ) {
+			return array();
+		}
+
 		$quizzes = $mlwQuizMasterNext->pluginHelper->get_quizzes(
 			false,
 			isset( $input['order_by'] ) ? sanitize_key( $input['order_by'] ) : 'quiz_id',
@@ -344,7 +354,8 @@ class QSM_Abilities {
 			array(),
 			'',
 			isset( $input['limit'] ) ? intval( $input['limit'] ) : '',
-			isset( $input['offset'] ) ? intval( $input['offset'] ) : ''
+			isset( $input['offset'] ) ? intval( $input['offset'] ) : '',
+			$access_where
 		);
 
 		$result = array();
@@ -370,6 +381,11 @@ class QSM_Abilities {
 	 */
 	public function execute_get_quiz( $input ) {
 		global $wpdb;
+
+		$access = $this->require_quiz_access( $input );
+		if ( is_wp_error( $access ) ) {
+			return $access;
+		}
 
 		$quiz = $wpdb->get_row(
 			$wpdb->prepare(
@@ -404,6 +420,11 @@ class QSM_Abilities {
 	 * @return array
 	 */
 	public function execute_list_questions( $input ) {
+		$access = $this->require_quiz_access( $input );
+		if ( is_wp_error( $access ) ) {
+			return $access;
+		}
+
 		return array_values( (array) QSM_Questions::load_questions( intval( $input['quiz_id'] ) ) );
 	}
 
@@ -415,6 +436,11 @@ class QSM_Abilities {
 	 * @return array|WP_Error
 	 */
 	public function execute_create_question( $input ) {
+		$access = $this->require_quiz_access( $input );
+		if ( is_wp_error( $access ) ) {
+			return $access;
+		}
+
 		$data = array(
 			'quiz_id' => intval( $input['quiz_id'] ),
 			'name'    => sanitize_text_field( $input['question_name'] ),
@@ -436,6 +462,71 @@ class QSM_Abilities {
 	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Denies an ability that names a quiz the current user does not own.
+	 *
+	 * The abilities are registered with a permission_callback that receives no
+	 * input (see register_abilities()), so it can only ever prove the flat
+	 * edit_qsm_quizzes capability -- a capability every role from Contributor up
+	 * holds. It structurally cannot check the quiz_id the caller supplied, which
+	 * makes a per-object check inside each execute callback the only place the
+	 * ownership rule can live. Without it these abilities are the same IDOR class
+	 * as CVE-2026-14825 / CVE-2026-14826 on a newer surface.
+	 *
+	 * Ownership is resolved by qsm_current_user_can_edit_quiz(), the same helper
+	 * the REST write routes use, so the two surfaces cannot drift apart.
+	 *
+	 * @since  9.1.0
+	 * @param  array $input Validated input data, expected to carry quiz_id.
+	 * @return true|WP_Error True when access is allowed, WP_Error otherwise.
+	 */
+	protected function require_quiz_access( $input ) {
+		$quiz_id = isset( $input['quiz_id'] ) ? intval( $input['quiz_id'] ) : 0;
+
+		if ( $quiz_id > 0 && function_exists( 'qsm_current_user_can_edit_quiz' ) && qsm_current_user_can_edit_quiz( $quiz_id ) ) {
+			return true;
+		}
+
+		// Fail closed: a missing quiz id, or a helper that could not be loaded, is
+		// a denial rather than a pass.
+		return new WP_Error(
+			'qsm_quiz_forbidden',
+			__( 'You are not allowed to access this quiz.', 'quiz-master-next' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	/**
+	 * Builds the quiz listing restriction for the current user.
+	 *
+	 * Mirrors require_quiz_access() for the unscoped listing: users who may edit
+	 * other people's quizzes see everything, everyone else is limited to the
+	 * quizzes qsm_get_editable_quiz_ids() reports for them. Returning false means
+	 * "owns nothing", which the caller turns into an empty list.
+	 *
+	 * @since  9.1.0
+	 * @return string|false A SQL fragment for get_quizzes(), '' for no restriction,
+	 *                      or false when the user owns no quiz at all.
+	 */
+	protected function quiz_access_where() {
+		if ( current_user_can( 'edit_others_qsm_quizzes' ) ) {
+			return '';
+		}
+
+		if ( ! function_exists( 'qsm_get_editable_quiz_ids' ) ) {
+			return false;
+		}
+
+		// Every id is cast to int by the helper, so the IN() list carries no
+		// caller-supplied text into the query.
+		$quiz_ids = array_filter( array_map( 'absint', qsm_get_editable_quiz_ids() ) );
+		if ( empty( $quiz_ids ) ) {
+			return false;
+		}
+
+		return 'quiz_id IN (' . implode( ',', $quiz_ids ) . ')';
+	}
 
 	/**
 	 * Builds the standard meta array for ability registration.

--- a/renderer/frontend/class-qsm-ajax-handler.php
+++ b/renderer/frontend/class-qsm-ajax-handler.php
@@ -89,6 +89,21 @@ class QSM_Ajax_Handler {
 				wp_send_json_error( array( 'message' => 'Quiz not found' ) );
 			}
 
+			// A deleted quiz has no questions to serve, and its lazy-load nonce
+			// stays valid for the rest of the nonce lifetime after deletion.
+			if ( ! empty( $quiz_options->deleted ) ) {
+				wp_send_json_error( array( 'message' => 'Quiz not found' ) );
+			}
+
+			// Honour the backing post's password. post_password_required() returns
+			// false once the visitor has entered the password, so a legitimate
+			// reader is unaffected; without this, the questions of a
+			// password-protected quiz are readable through this endpoint by anyone
+			// holding the (shared, anonymous) lazy-load nonce.
+			if ( self::quiz_password_required( $quiz_id ) ) {
+				wp_send_json_error( array( 'message' => 'This quiz is password protected.' ) );
+			}
+
 			// Render questions HTML
 			$html = self::render_page_questions(
 				$quiz_id,
@@ -123,6 +138,41 @@ class QSM_Ajax_Handler {
 	}
 
 	/**
+	 * Whether the quiz's backing post is password protected for this visitor.
+	 *
+	 * Mirrors the check QMNQuizManager::ajax_submit_results() applies to the
+	 * submission endpoint, so reading a quiz's questions is not easier than
+	 * submitting to it. Users who may edit quizzes are exempt, matching the
+	 * exemption the submission endpoint already makes for them.
+	 *
+	 * @param  int $quiz_id Quiz ID.
+	 * @return bool True when the questions must not be served.
+	 */
+	private static function quiz_password_required( $quiz_id ) {
+		if ( current_user_can( 'edit_qsm_quizzes' ) ) {
+			return false;
+		}
+
+		$post_ids = get_posts(
+			array(
+				'post_type'   => 'qsm_quiz',
+				'meta_key'    => 'quiz_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Mirrors the submission endpoint's lookup.
+				'meta_value'  => intval( $quiz_id ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Mirrors the submission endpoint's lookup.
+				'fields'      => 'ids',
+				'numberposts' => 1,
+			)
+		);
+
+		if ( empty( $post_ids[0] ) ) {
+			return false;
+		}
+
+		$post_obj = get_post( $post_ids[0] );
+
+		return $post_obj instanceof WP_Post && post_password_required( $post_obj );
+	}
+
+	/**
 	 * Render questions for a specific page
 	 *
 	 * @param int    $quiz_id              Quiz ID
@@ -139,12 +189,21 @@ class QSM_Ajax_Handler {
 			$randomness_order = array();
 		}
 		
-		// Get questions from database
+		// Get questions from database.
+		//
+		// Security: the question ids arrive in the request body and are entirely
+		// attacker-controlled, while the nonce only proves the caller can see the
+		// quiz named by $quiz_id -- for a logged-out visitor that nonce is the same
+		// value every anonymous visitor of any public quiz receives. Constraining
+		// the lookup to this quiz is therefore what keeps the endpoint from
+		// rendering any question on the site (questions belonging to quizzes behind
+		// a login, a membership plugin or a password) to an unauthenticated caller.
 		$questions = array();
 		foreach ( $question_ids as $question_id ) {
 			$question = $wpdb->get_row( $wpdb->prepare(
-				"SELECT * FROM {$wpdb->prefix}mlw_questions WHERE question_id = %d AND deleted = 0",
-				$question_id
+				"SELECT * FROM {$wpdb->prefix}mlw_questions WHERE question_id = %d AND quiz_id = %d AND deleted = 0",
+				$question_id,
+				$quiz_id
 			), ARRAY_A );
 
 			if ( ! $question ) {


### PR DESCRIPTION
Fixes the two High-severity findings from the QSM security audit (ClickUp [CU-86d420kux](https://app.clickup.com/t/86d420kux)). Both are the same broken-object-level-authorization class as CVE-2026-14825 / CVE-2026-14826, on two surfaces added *after* those fixes that were never added to the route inventory.

Scoped to the two High findings only — the 5 Medium and 8 Low findings in the audit are deliberately left for follow-up PRs.

## H-1 — Abilities API had no per-quiz authorization

`php/classes/class-qsm-abilities.php`

All four abilities (`list-quizzes`, `get-quiz`, `list-questions`, `create-question`) gated only on `permission_edit_quizzes()` → `current_user_can( 'edit_qsm_quizzes' )`, a flat capability the plugin grants to **Contributor and above**. The `quiz_id` came from caller input and was never checked.

The registered `permission_callback` (`register_abilities()`, ~L177) receives **no `$input`/`$request` argument**, so it structurally cannot do a per-object check — the gate has to live inside each execute callback, and none of them had one.

- Added `require_quiz_access()`, which resolves ownership through `qsm_current_user_can_edit_quiz()` — the same helper the REST write routes use, so the two surfaces cannot drift apart — and **fails closed** on a missing quiz id or an unloadable helper.
- Wired it into `execute_get_quiz()`, `execute_list_questions()` and `execute_create_question()`.
- Added `quiz_access_where()` and passed it to `get_quizzes()` as the `$where` argument, so `execute_list_quizzes()` is scoped **in SQL** (keeping `LIMIT`/`OFFSET` consistent with the rows returned) rather than filtered after the fetch. Holders of `edit_others_qsm_quizzes` are unrestricted; a user who owns nothing gets an empty list. The `IN()` list is built only from ints returned by `qsm_get_editable_quiz_ids()`.

## H-2 — Unauthenticated cross-quiz question disclosure

`renderer/frontend/class-qsm-ajax-handler.php`

`render_page_questions()` looked up each id from the request body with only `question_id = %d AND deleted = 0` — **no `quiz_id` constraint**. The `qsm_lazy_load_<quiz_id>` nonce is localized to every visitor of any quiz page and, for logged-out visitors, is the same value for every anonymous user. So any anonymous visitor to one public quiz could enumerate ids and render every question on the site, including questions in quizzes behind a login, a membership plugin, or a password.

- Constrained the lookup to `AND quiz_id = %d`. This is the fix for the disclosure; within a single quiz there is no boundary to enforce, since the visitor is taking that quiz.
- Added a `post_password_required()` gate mirroring the one `QMNQuizManager::ajax_submit_results()` already applies, so reading a quiz's questions is not easier than submitting to it. Users who may edit quizzes are exempt, matching the submission endpoint.
- Rejected deleted quizzes, whose lazy-load nonce otherwise stays valid for the rest of the nonce lifetime.

## Verification

`php -l` clean on both files (PHP 8.0.30), and both were exercised live on the `qsm-play` InstaWP sandbox using the three-column method from the KB harness page — **column A = `pre-release` @ `8a7f26f2` unpatched, column B = this branch** — against identical fixtures (an administrator's quiz + question, a contributor who owns one quiz of their own).

**H-2 — real anonymous HTTP POST to `admin-ajax.php`, no cookies:**

| assertion | column A (unpatched) | column B (this branch) |
|---|---|---|
| `quiz_id=<own>`, `question_ids=<foreign>` → leaks the other quiz's question | **leaked** ❌ | denied ✅ |
| `quiz_id=<own>`, `question_ids=<own>` → renders normally | renders ✅ | renders ✅ |
| mixed `own,foreign` → own rendered, foreign dropped | both rendered ❌ | own only ✅ |

The mixed case matters: the fix filters per question rather than rejecting the whole request, so a stale client id list degrades gracefully instead of breaking the page.

**H-1 — abilities invoked as a Contributor:**

| assertion | column A | column B |
|---|---|---|
| `get-quiz(victim)` | ALLOWED ❌ | `qsm_quiz_forbidden` ✅ |
| `list-questions(victim)` | ALLOWED ❌ | `qsm_quiz_forbidden` ✅ |
| `create-question(victim)` | ALLOWED — **wrote a row into the victim's quiz** ❌ | `qsm_quiz_forbidden` ✅ |
| `get-quiz(own)` — must keep working | ALLOWED ✅ | ALLOWED ✅ |
| `list-quizzes` | all 3 quizzes ❌ | own quiz only ✅ |
| administrator control: get / list-questions / list-quizzes | unchanged ✅ | unchanged ✅ |
| attacker rows written to victim quiz | 1 ❌ | 0 ✅ |

`$wpdb->last_error` empty throughout; the sandbox was restored to its 11.2.3 baseline afterwards.

## Not addressed here (deliberate)

The audit also noted this endpoint never checks the owning quiz's **publish status** or `require_log_in`. Both are left out on purpose: quizzes are commonly embedded by shortcode in an ordinary published post whose backing `qsm_quiz` post is a draft, so mirroring the submission endpoint's `'publish' !== $post_status` rule here risks breaking legitimate quizzes, and I could not verify that safely. `require_log_in` enforcement belongs with M-1 (the submission path), where the consequential action is. Both are called out in the ClickUp task.

Two fixture rows may remain in the sandbox DB — cleanup was gate-denied as destructive and needs a human.

Agentric session: https://ai.expresstech.io/#/sessions/aos-ses_675920e6c76bb3fa
