### PR TITLE
Fix multiple choice points with limited answers

### DIFF
--- a/php/classes/class-qmn-plugin-helper.php
+++ b/php/classes/class-qmn-plugin-helper.php
@@ -1314,10 +1314,14 @@ class QMNPluginHelper {
 	public function qsm_get_limited_options( $options, $limit ) {
 		$correct   = array_filter( $options, fn( $o, $k ) => 1 == $o[2], ARRAY_FILTER_USE_BOTH );
 		$incorrect = array_filter( $options, fn( $o, $k ) => 0 == $o[2], ARRAY_FILTER_USE_BOTH );
-		shuffle( $incorrect );
-		$final = array_merge( $correct, array_slice( $incorrect, 0, $limit - count( $correct ) ) );
-		shuffle( $final );
-		$final_keys = array_map( fn( $k ) => array_search( $k, array_values( $options ), true ), $final );
+		$incorrect_keys = array_keys( $incorrect );
+		shuffle( $incorrect_keys );
+		$final_keys = array_merge( array_keys( $correct ), array_slice( $incorrect_keys, 0, $limit - count( $correct ) ) );
+		shuffle( $final_keys );
+		$final = array();
+		foreach ( $final_keys as $final_key ) {
+			$final[ $final_key ] = $options[ $final_key ];
+		}
 		return array(
 			'final'             => $final,
 			'answer_limit_keys' => implode( ',', $final_keys ),


### PR DESCRIPTION
## Problem

Multiple Choice questions could receive incorrect point values when answer limits were enabled. The displayed answers were shuffled and reindexed, but the submitted indexes were matched against the original answer array.

This caused POINT_SCORE to be lower than expected while MAXIMUM_POINTS remained correct.

## Fix

Preserve the original answer indexes when limiting and shuffling answer options. Submitted answers now map to the correct stored point values.

Fixes #3237

## Validation

- Tested the affected quiz and confirmed the expected score.
- PHP syntax check passed for the modified file.