### PR TITLE
Prepare Question Bank queries once instead of twice (no behaviour change)

### DIFF
--- a/php/rest-api.php
+++ b/php/rest-api.php
@@ -221,16 +221,22 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 			$migrated = true;
 		}
 
-		$search_sql = '';
+		// The search and type filters are optional, so they are built as a SQL
+		// fragment spliced into each query below. Keep the fragment as PLACEHOLDERS
+		// and carry its values in $search_args, so every query is prepared exactly
+		// once. Preparing the fragment separately and interpolating the result would
+		// feed already-substituted values back through prepare() a second time.
+		$search_sql  = '';
+		$search_args = array();
 		if ( ! empty( $search ) ) {
-			$search_sql .= $wpdb->prepare(
-				" AND (question_settings LIKE %s OR question_name LIKE %s)",
-				'%' . $wpdb->esc_like( $search ) . '%',
-				'%' . $wpdb->esc_like( $search ) . '%'
-			);
+			$search_sql   .= ' AND (question_settings LIKE %s OR question_name LIKE %s)';
+			$search_like   = '%' . $wpdb->esc_like( $search ) . '%';
+			$search_args[] = $search_like;
+			$search_args[] = $search_like;
 		}
 		if ( ! empty( $que_type ) ) {
-			$search_sql .= $wpdb->prepare( " AND question_type_new = %s", $que_type );
+			$search_sql   .= ' AND question_type_new = %s';
+			$search_args[] = $que_type;
 		}
 
 		$question_ids     = array();
@@ -249,12 +255,12 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 					$category_id_list = implode( ',', $question_ids );
 				}
 				$query = "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND question_id IN ($category_id_list) AND quiz_id LIKE %s $search_sql$access_sql";
-				$query = $wpdb->prepare( $query, $quiz_filter );
+				$query = $wpdb->prepare( $query, array_merge( array( $quiz_filter ), $search_args ) );
 			} else {
-				$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql$access_sql", $category, $quiz_filter );
+				$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql$access_sql", array_merge( array( $category, $quiz_filter ), $search_args ) );
 			}
 		} else {
-			$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql$access_sql", $quiz_filter );
+			$query = $wpdb->prepare( "SELECT COUNT(question_id) as total_question FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql$access_sql", array_merge( array( $quiz_filter ), $search_args ) );
 		}
 		$total_count_query = $wpdb->get_row( $query, 'ARRAY_A' );
 		$total_count = isset( $total_count_query['total_question'] ) ? $total_count_query['total_question'] : 0;
@@ -275,13 +281,13 @@ function qsm_rest_get_bank_questions( WP_REST_Request $request ) {
 				// applied the page OFFSET to every single-row query, so page 1 returned
 				// the whole category and every "Load more" page after it returned nothing.
 				$query     = "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND question_id IN ($category_id_list) AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d";
-				$questions = $wpdb->get_results( $wpdb->prepare( $query, $quiz_filter, $offset, $limit ), 'ARRAY_A' );
+				$questions = $wpdb->get_results( $wpdb->prepare( $query, array_merge( array( $quiz_filter ), $search_args, array( $offset, $limit ) ) ), 'ARRAY_A' );
 			} else {
-				$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d", $category, $quiz_filter, $offset, $limit );
+				$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND category = %s AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d", array_merge( array( $category, $quiz_filter ), $search_args, array( $offset, $limit ) ) );
 				$questions = $wpdb->get_results( $query, 'ARRAY_A' );
 			}
 		} else {
-			$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d", $quiz_filter, $offset, $limit );
+			$query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_questions WHERE deleted = 0 AND deleted_question_bank = 0 AND quiz_id LIKE %s $search_sql$access_sql ORDER BY question_order ASC LIMIT %d, %d", array_merge( array( $quiz_filter ), $search_args, array( $offset, $limit ) ) );
 			$questions = $wpdb->get_results( $query, 'ARRAY_A' );
 		}
 


### PR DESCRIPTION
## Read this first: the reported bug is not real

This branch was opened against task `tsk_d1976ccb58acbf4c`, which reported that Question Bank
search **silently returns nothing** for terms starting with `s`/`d`/`f`/`F`/`i` (`sales`, `form`,
`info`, `date`, `Final`), because `$search_sql` is prepared once and then passed through
`$wpdb->prepare()` a second time.

**I could not reproduce that, and I believe it does not happen on any WordPress QSM supports.**

`wpdb::prepare()` ends in `add_placeholder_escape( $query )`, and `wpdb::_real_escape()` — which
escapes every substituted value — also ends in `add_placeholder_escape()`. Both replace every `%`
with a per-request HMAC token. So by the time the inner `prepare()` returns, its output contains
**no live `%` at all**:

```
inner prepare() output, raw bytes:
   AND (question_settings LIKE '{a5e503cf…9789b9}sales{a5e503cf…9789b9}' OR question_name LIKE '…')
```

The outer `prepare()` therefore sees nothing that looks like a placeholder, and
`remove_placeholder_escape()` (hooked onto the `query` filter at priority 0) restores the `%`
before the query runs. `add_placeholder_escape()` has shipped since WP **4.8.3**; QSM's
`Requires at least` is **5.0**, so every supported install has it.

Verified by extracting the real `wpdb` from **WP 6.7.7** (`wp-includes/class-wpdb.php` on
`qsm-production`, PHP 7.4.33) and running the actual query shapes through it — the real core file,
not a re-typed stub:

```
search='sales', current code, no-category SELECT
  notices: (none)
  result : … quiz_id LIKE '%'  AND (question_settings LIKE '%sales%'
                                    OR question_name LIKE '%sales%') … LIMIT 0, 20
```

The ticket's exact error — *"does not contain the correct number of placeholders (5) for the number
of arguments passed (3)"*, matching numbers and all — reproduces **only** when
`add_placeholder_escape()`/`remove_placeholder_escape()` are stubbed to identity, i.e. when the
harness removes the very mechanism that makes the double-prepare safe:

```
RealWpdb     (production semantics)          → notices: (none)   result: correct SQL
NoEscapeWpdb (placeholder escape disabled)   → notices: wpdb::prepare: The query does not contain
                                                the correct number of placeholders (5) for the
                                                number of arguments passed (3).
                                              result: <EMPTY — query killed>
```

So `sales`, `form`, `info`, `date` and `Final` all search correctly on `dev` today. **This PR fixes
no user-visible defect and should not get a changelog entry claiming one.**

## What this PR actually does

The double-prepare works, but only by accident of a core implementation detail. It is also a
genuine `WordPress.DB.PreparedSQL` finding, and it is a trap for the next person to edit this
function: append one fragment that *isn't* the output of `prepare()` and it becomes an injection.

So: build the search/type fragment as **placeholders only**, carry its values in `$search_args`, and
splice them into the single outer `prepare()` at the position the fragment occupies.

```php
$search_sql   .= ' AND (question_settings LIKE %s OR question_name LIKE %s)';
$search_like   = '%' . $wpdb->esc_like( $search ) . '%';
$search_args[] = $search_like;
$search_args[] = $search_like;
…
$query = $wpdb->prepare( $query, array_merge( array( $quiz_filter ), $search_args ) );
```

## Verification

`php -l` clean (PHP 7.4.33). Equivalence was measured by extracting the query-building region from
**both file versions verbatim** (no hand-copied replica) and `eval`ing each against the real WP
6.7.7 `wpdb` with `get_row`/`get_results` recording instead of executing:

| | |
|---|---|
| scenarios | **192** — 12 search terms (incl. `50% off`, `a_b`, `O'Brien`, `100%`, `%%`, empty) × type filter on/off × 4 category branches × 2 pages |
| queries compared | 384 |
| byte-identical old vs new | **192 / 192** |
| empty / killed queries | 0 |
| `_doing_it_wrong` notices | 0 |

Falsifier — the same harness with one `$search_args[]` line deleted: **176 / 192 differ**, 352
queries killed, notices fired. So the clean run is meaningful rather than vacuous.

Not runtime-verified against a live WordPress: a PHP harness cannot see the admin screen render.

## Base

Branched off `fix/question-bank-category-filter`, not `dev` — that branch rewrites the same lines
(the `IN ()` and pagination fixes). **Merge that one first**; this retargets to `dev` automatically.

Agentric session: https://ai.expresstech.io/#/sessions/aos-ses_042acc869bf74f63
