### PR TITLE
Cu 86d46frxv fix qsm result enumeration

### DIFF
--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -531,8 +531,9 @@ class QMNQuizManager {
 					wp_add_inline_script( 'math_jax', self::$default_MathJax_script, 'before' );
 				}
 
-				$result_id      = $result['result_id'];
-				$return_display = do_shortcode( '[qsm_result id="' . $result_id . '"]' );
+				// Hand the TOKEN on, not the primary key: the inner shortcode has to be able to
+				// tell a validated share link from a guessed id.
+				$return_display = do_shortcode( '[qsm_result unique_id="' . esc_attr( $result_unique_id ) . '"]' );
 				$return_display = str_replace( '%FB_RESULT_ID%', esc_js( esc_attr( $result_unique_id ) ), $return_display );
 			} else {
 				$return_display = esc_html__( 'Result id is wrong!', 'quiz-master-next' );
@@ -737,20 +738,59 @@ class QMNQuizManager {
 
 		$args = shortcode_atts(
 			array(
-				'id' => 0,
+				'id'        => 0,
+				'unique_id' => '',
 			),
 			$atts
 		);
 
-		$id = intval( $args['id'] );
+		global $mlwQuizMasterNext;
+		global $wpdb;
+
+		/*
+		 * The `id` attribute is author-supplied: it only ever reaches us from page
+		 * content, or from an internal caller that has already validated a share token.
+		 * It stays trusted.
+		 *
+		 * `?result_id=` in the URL is not. It is ALWAYS resolved as the unguessable
+		 * `unique_id` share token, never as the sequential mlw_results primary key.
+		 * Looking it up by primary key let an unauthenticated visitor walk
+		 * ?result_id=1,2,3... and read every stored result, including the submitter's
+		 * name, email, phone and IP address.
+		 */
+		$id             = intval( $args['id'] );
+		$token          = sanitize_text_field( $args['unique_id'] );
+		$trusted_source = ( $id > 0 );
 
 		ob_start();
-		if ( 0 === $id ) {
-			$id = (int) isset( $_GET['result_id'] ) ? sanitize_text_field( wp_unslash( $_GET['result_id'] ) ) : 0;
+
+		if ( 0 === $id && '' === $token && isset( $_GET['result_id'] ) && '' !== $_GET['result_id'] ) {
+			$token = sanitize_text_field( wp_unslash( $_GET['result_id'] ) );
 		}
-		if ( $id && is_numeric( $id ) ) {
-			global $mlwQuizMasterNext;
-			global $wpdb;
+
+		if ( '' !== $token ) {
+			$id = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT result_id FROM {$wpdb->prefix}mlw_results WHERE unique_id = %s LIMIT 1",
+					$token
+				)
+			);
+
+			if ( $id > 0 ) {
+				$trusted_source = true;
+			} elseif ( is_numeric( $token ) && apply_filters( 'qsm_allow_numeric_result_id', false, $token ) ) {
+				/*
+				 * Transition escape hatch for sites that published numeric result links
+				 * before this was tightened. Off by default and deliberately filter-only,
+				 * with no UI setting, because switching it on restores the old behaviour
+				 * in full: sequential ids become guessable again on that site.
+				 */
+				$id             = intval( $token );
+				$trusted_source = true;
+			}
+		}
+
+		if ( $id ) {
 			$result_data = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}mlw_results WHERE result_id = %d", $id ), ARRAY_A );
 			if ( $result_data ) {
 				$current_user_id = get_current_user_id();
@@ -764,7 +804,22 @@ class QMNQuizManager {
 				$can_view_result = apply_filters( 'qsm_can_view_result', $can_view_result, $id, $result_data, $current_user_id );
 				$qmn_settings           = (array) get_option( 'qmn-settings' );
 				$result_link_visibility = ! empty( $qmn_settings['result_link_visibility'] ) ? $qmn_settings['result_link_visibility'] : 0;
-				if ( ! $can_view_result && $result_link_visibility ) {
+
+				/*
+				 * A valid share token -- or an id an editor placed in page content -- is itself
+				 * the authorization to view this result. That is what the sharing feature is
+				 * for. Result Link Visibility stays the strict mode layered on top: with it on,
+				 * even a valid share link requires an owner or a capability holder.
+				 *
+				 * Granting explicitly, rather than making the deny conditional, is what stops
+				 * this failing open: before, an unauthorized viewer simply fell through to the
+				 * render whenever the setting was off, which is the default.
+				 */
+				if ( ! $can_view_result && $trusted_source && ! $result_link_visibility ) {
+					$can_view_result = true;
+				}
+
+				if ( ! $can_view_result ) {
 					esc_html_e( 'You do not have permission to view this result.', 'quiz-master-next' );
 					$content = ob_get_clean();
 					return $content;

--- a/renderer/frontend/class-qsm-new-renderer.php
+++ b/renderer/frontend/class-qsm-new-renderer.php
@@ -239,8 +239,9 @@ class QSM_New_Renderer {
 				wp_add_inline_script( 'math_jax', self::$default_MathJax_script, 'before' );
 			}
 
-			$result_id      = $result['result_id'];
-			$return_display = do_shortcode( '[qsm_result id="' . $result_id . '"]' );
+			// Hand the TOKEN on, not the primary key: the inner shortcode has to be able to
+			// tell a validated share link from a guessed id.
+			$return_display = do_shortcode( '[qsm_result unique_id="' . esc_attr( $result_unique_id ) . '"]' );
 			$return_display = str_replace( '%FB_RESULT_ID%', esc_js( esc_attr( $result_unique_id ) ), $return_display );
 		} else {
 			$return_display = esc_html__( 'Result id is wrong!', 'quiz-master-next' );


### PR DESCRIPTION
[qsm_result] read ?result_id= from the URL and looked the record up by mlw_results.result_id, which is mediumint AUTO_INCREMENT. The ownership check after that lookup only denied when the result_link_visibility setting was on, and it ships off, so on a default install an unauthenticated visitor could walk ?result_id=1,2,3... and read every stored result: name, email, phone, IP, answers and score.

Turning the setting on is not a fix. The sharing feature resolves the unguessable unique_id token to a result_id and then re-enters this handler as [qsm_result id="N"], so by the time the guard runs it can no longer tell a valid share link from a guessed integer -- any setting that blocks the guess also blocks the link.

Preserve that signal instead:

- shortcode_display_result() gains a unique_id attribute. A visitor supplied ?result_id= is now always resolved via WHERE unique_id = %s, never via WHERE result_id = %d. The id attribute stays trusted because it only comes from page content.
- The guard grants explicitly -- a valid token, or an author-placed id, authorizes the view unless result_link_visibility is on -- so the deny no longer needs a setting enabled in order to exist.
- Both internal hand-offs (QMNQuizManager::display_quiz and QSM_New_Renderer::render_result_page) pass the token through rather than laundering it into a numeric id.

Also removes a misplaced (int) cast that applied to isset() rather than to the value, leaving $id a string from $_GET.

Behaviour change: numeric ?result_id= URLs no longer resolve. Sites that published such links can opt back in with the qsm_allow_numeric_result_id filter, which is off by default and has no UI, since enabling it restores the guessable behaviour. Token links, [qsm_result id="N"] in content, and admin/owner access are unchanged.

### Merge Checklist

Please check all of the following items before merging

- [ ] No new WPCS issues
- [ ] No notices, warnings or errors in debug.log
- [ ] No sonar cloud issues
- [ ] No errors while running automated tests
