### PR TITLE
Show quiz results after their quiz is deleted from the database

### DIFF
--- a/php/admin/admin-results-details-page.php
+++ b/php/admin/admin-results-details-page.php
@@ -90,17 +90,37 @@ function qsm_generate_results_details_tab() {
     }
 	// Prepare plugin helper.
 	$quiz_id = intval( $results_data->quiz_id );
-	$mlwQuizMasterNext->pluginHelper->prepare_quiz( $quiz_id );
+	// False when the quiz was deleted from the database. The result itself still holds
+	// everything needed to display it, only the per quiz settings are unavailable.
+	$quiz_loaded = $mlwQuizMasterNext->pluginHelper->prepare_quiz( $quiz_id );
 
     $quiz_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'quiz_id' AND meta_value = %d", $quiz_id ) );
     $post_author = get_post_field( 'post_author', $quiz_post_id, true );
-    if ( ( ! current_user_can( 'view_qsm_quiz_result' ) || intval($post_author) != get_current_user_id()) && ! current_user_can( 'delete_others_qsm_quizzes' ) ) {
+    // The quiz can be gone while the result is not, in which case there is no author
+    // to compare against and only a user who may see other people's quizzes can view it.
+    $quiz_exists = ! empty( $quiz_post_id );
+    if ( ( ! current_user_can( 'view_qsm_quiz_result' ) || ! $quiz_exists || intval($post_author) != get_current_user_id()) && ! current_user_can( 'delete_others_qsm_quizzes' ) ) {
+        $resultpage_link = admin_url('admin.php?page=mlw_quiz_results');
+        ?>
+        <div id="qsm-dashboard-error-container">
+            <div class="qsm-dashboard-error-content">
+                <h3><?php esc_html_e('Quiz Result Not Available', 'quiz-master-next'); ?></h3>
+                <p><?php esc_html_e('You do not have permission to view this quiz result.', 'quiz-master-next'); ?></p>
+                <a href="<?php echo esc_url($resultpage_link); ?>" class="qsm-dashboard-error-btn">
+                    <?php esc_html_e('Back to All Results', 'quiz-master-next'); ?>
+                </a>
+            </div>
+        </div>
+        <?php
         return;
     }
 
     //Get the data for comments
     $quiz_options = $mlwQuizMasterNext->quiz_settings->get_setting( 'quiz_options');
-    $comments_enabled = $quiz_options['comment_section'];
+    // get_setting() returns false when the quiz no longer exists, so the per quiz
+    // options fall back to their defaults instead of being read off a boolean.
+    $quiz_options = is_array( $quiz_options ) ? $quiz_options : array();
+    $comments_enabled = isset( $quiz_options['comment_section'] ) ? $quiz_options['comment_section'] : '';
 
     $previous_results = $wpdb->get_var( $wpdb->prepare("SELECT result_id FROM {$wpdb->prefix}mlw_results WHERE result_id = (SELECT MAX(result_id) FROM {$wpdb->prefix}mlw_results WHERE deleted = 0 AND result_id < %d)",  $result_id));
     $next_results     = $wpdb->get_var( $wpdb->prepare("SELECT result_id FROM {$wpdb->prefix}mlw_results WHERE result_id = (SELECT MIN(result_id) FROM {$wpdb->prefix}mlw_results WHERE deleted = 0 AND result_id > %d)", $result_id));
@@ -111,6 +131,9 @@ function qsm_generate_results_details_tab() {
 		wp_enqueue_script( 'math_jax', QSM_PLUGIN_JS_URL . '/mathjax/tex-mml-chtml.js', false, '3.2.0', true );
 		wp_add_inline_script( 'math_jax', $mlwQuizMasterNext::$default_MathJax_script, 'before' );
 	}
+    if ( ! $quiz_loaded ) {
+        echo '<div class="notice notice-warning inline"><p>' . esc_html__( 'The quiz this result belongs to has been deleted. The stored result is shown below, without the quiz specific settings.', 'quiz-master-next' ) . '</p></div>';
+    }
     echo '<div style="text-align:right; margin-top: 20px; margin-bottom: 20px;">';
     echo '<h3 class="result-page-title">'.esc_html__('Quiz Result','quiz-master-next').' - '. esc_html( $results_data->quiz_name ) .'</h3>';
     do_action( 'qsm_above_admin_results' );

--- a/php/classes/class-qmn-plugin-helper.php
+++ b/php/classes/class-qmn-plugin-helper.php
@@ -1124,8 +1124,10 @@ class QMNPluginHelper {
 	public function convert_to_preferred_date_format( $qsm_qna_array ) {
 		global $mlwQuizMasterNext;
 		$quiz_options        = $mlwQuizMasterNext->quiz_settings->get_quiz_options();
-		$qsm_quiz_settings   = maybe_unserialize( $quiz_options->quiz_settings );
-		$qsm_quiz_options    = maybe_unserialize( $qsm_quiz_settings['quiz_options'] );
+		// The quiz may no longer exist, e.g. when viewing a result whose quiz was
+		// deleted from the database, so fall back to the plugin/WordPress format.
+		$qsm_quiz_settings   = isset( $quiz_options->quiz_settings ) ? maybe_unserialize( $quiz_options->quiz_settings ) : array();
+		$qsm_quiz_options    = isset( $qsm_quiz_settings['quiz_options'] ) ? maybe_unserialize( $qsm_quiz_settings['quiz_options'] ) : array();
 		$qsm_global_settings = get_option( 'qsm-quiz-settings' );
 		// check if preferred date format is set at quiz level or plugin level. Default to WP date format otherwise
 		if ( isset( $qsm_quiz_options['preferred_date_format'] ) ) {

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -507,9 +507,14 @@ class QMNQuizManager {
 		$is_proper_quiz   = ( false !== $has_proper_quiz['res'] );
 		$showing_result   = ( isset( $_GET['result_id'] ) && '' !== $_GET['result_id'] );
 
-		// A stored result stays viewable after its quiz was deleted, so only stop here
-		// when the quiz is needed to take the quiz itself.
-		if ( ! $is_proper_quiz && ! $showing_result ) {
+		// A stored result stays viewable after its quiz was deleted from the database,
+		// so only stop here when the quiz is still there to say something about itself,
+		// e.g. a quiz that was moved to the trash keeps reporting that.
+		$quiz_row_exists = true;
+		if ( ! $is_proper_quiz && $showing_result ) {
+			$quiz_row_exists = (bool) $wpdb->get_var( $wpdb->prepare( "SELECT quiz_id FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d LIMIT 1", $quiz ) );
+		}
+		if ( ! $is_proper_quiz && ( ! $showing_result || $quiz_row_exists ) ) {
 			return $has_proper_quiz['message'];
 		}
 
@@ -539,8 +544,6 @@ class QMNQuizManager {
 				$result_id      = $result['result_id'];
 				$return_display = do_shortcode( '[qsm_result id="' . $result_id . '"]' );
 				$return_display = str_replace( '%FB_RESULT_ID%', esc_js( esc_attr( $result_unique_id ) ), $return_display );
-			} elseif ( ! $is_proper_quiz ) {
-				$return_display = $has_proper_quiz['message'];
 			} else {
 				$return_display = esc_html__( 'Result id is wrong!', 'quiz-master-next' );
 			}

--- a/php/classes/class-qmn-quiz-manager.php
+++ b/php/classes/class-qmn-quiz-manager.php
@@ -503,17 +503,22 @@ class QMNQuizManager {
 		$question_amount = intval( $shortcode_args['question_amount'] );
 
 		// Check, if quiz is setup properly.
-		$has_proper_quiz = $mlwQuizMasterNext->pluginHelper->has_proper_quiz( $quiz );
-		if ( false === $has_proper_quiz['res'] ) {
+		$has_proper_quiz  = $mlwQuizMasterNext->pluginHelper->has_proper_quiz( $quiz );
+		$is_proper_quiz   = ( false !== $has_proper_quiz['res'] );
+		$showing_result   = ( isset( $_GET['result_id'] ) && '' !== $_GET['result_id'] );
+
+		// A stored result stays viewable after its quiz was deleted, so only stop here
+		// when the quiz is needed to take the quiz itself.
+		if ( ! $is_proper_quiz && ! $showing_result ) {
 			return $has_proper_quiz['message'];
 		}
 
-		$qmn_quiz_options = $has_proper_quiz['qmn_quiz_options'];
+		$qmn_quiz_options = $is_proper_quiz ? $has_proper_quiz['qmn_quiz_options'] : null;
 		$qmn_quiz_options = apply_filters( 'qsm_quiz_option_before', $qmn_quiz_options );
 		$return_display   = '';
 
 		ob_start();
-		if ( isset( $_GET['result_id'] ) && '' !== $_GET['result_id'] ) {
+		if ( $showing_result ) {
 			$result_unique_id = sanitize_text_field( wp_unslash( $_GET['result_id'] ) );
 			$result           = $wpdb->get_row( $wpdb->prepare( "SELECT `result_id`, `quiz_id` FROM {$wpdb->prefix}mlw_results WHERE unique_id = %s", $result_unique_id ), ARRAY_A );
 			if ( ! empty( $result ) && isset( $result['result_id'] ) ) {
@@ -534,6 +539,8 @@ class QMNQuizManager {
 				$result_id      = $result['result_id'];
 				$return_display = do_shortcode( '[qsm_result id="' . $result_id . '"]' );
 				$return_display = str_replace( '%FB_RESULT_ID%', esc_js( esc_attr( $result_unique_id ) ), $return_display );
+			} elseif ( ! $is_proper_quiz ) {
+				$return_display = $has_proper_quiz['message'];
 			} else {
 				$return_display = esc_html__( 'Result id is wrong!', 'quiz-master-next' );
 			}

--- a/php/classes/class-qsm-results-pages.php
+++ b/php/classes/class-qsm-results-pages.php
@@ -361,17 +361,18 @@ class QSM_Results_Pages {
 		}
 
 		global $wpdb;
-		$results = $wpdb->get_var( $wpdb->prepare( "SELECT message_after FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d", $quiz_id ) );
+		$quiz = $wpdb->get_row( $wpdb->prepare( "SELECT message_after FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d", $quiz_id ), ARRAY_A );
 
 		// The quiz itself can be gone while its results are still viewable, e.g. after
 		// it was deleted from the database. There is no results page to load then, and
 		// returning no pages lets generate_pages() fall back to its own default so the
-		// questions and answers still render.
-		if ( is_null( $results ) ) {
+		// questions and answers still render. The row is what is tested, not the column:
+		// message_after is nullable on installs that went through the 7.3.11 upgrade.
+		if ( is_null( $quiz ) ) {
 			return $pages;
 		}
 
-		$results = maybe_unserialize( $results );
+		$results = maybe_unserialize( $quiz['message_after'] );
 
 		// Checks if the results is an array.
 		if ( is_array( $results ) ) {

--- a/php/classes/class-qsm-results-pages.php
+++ b/php/classes/class-qsm-results-pages.php
@@ -362,6 +362,15 @@ class QSM_Results_Pages {
 
 		global $wpdb;
 		$results = $wpdb->get_var( $wpdb->prepare( "SELECT message_after FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d", $quiz_id ) );
+
+		// The quiz itself can be gone while its results are still viewable, e.g. after
+		// it was deleted from the database. There is no results page to load then, and
+		// returning no pages lets generate_pages() fall back to its own default so the
+		// questions and answers still render.
+		if ( is_null( $results ) ) {
+			return $pages;
+		}
+
 		$results = maybe_unserialize( $results );
 
 		// Checks if the results is an array.
@@ -401,6 +410,12 @@ class QSM_Results_Pages {
 		global $wpdb;
 		global $mlwQuizMasterNext;
 		$data      = $wpdb->get_row( $wpdb->prepare( "SELECT message_after FROM {$wpdb->prefix}mlw_quizzes WHERE quiz_id = %d", $quiz_id ), ARRAY_A );
+
+		// Nothing to convert, and nothing to write back, when the quiz no longer exists.
+		if ( empty( $data ) ) {
+			return $pages;
+		}
+
 		$system    = $mlwQuizMasterNext->pluginHelper->get_section_setting( 'quiz_options', 'system', 0 );
 		$old_pages = maybe_unserialize( $data['message_after'] );
 


### PR DESCRIPTION
## The problem

A quiz's results keep loading fine while the quiz exists, including after a plain delete. Once the quiz is deleted **from the database** (the "Delete items from database?" checkbox, or Tools -> Deleted Quiz -> Delete Permanently), the results that belong to it stop loading properly on the **admin detailed results page** and through the **result page link**.

The results themselves are not the problem. `QMNQuizCreator::delete_quiz()` never touches `mlw_results`, `qsm_results_questions` or `qsm_results_meta` in any branch, and there is no foreign key from results to quizzes, so the rows survive intact and are still listed on the Results page. What breaks is the code that re-derives quiz level state from the `mlw_quizzes` row: `QMNPluginHelper::prepare_quiz()` returns `false` without setting the quiz ids, callers ignore that return, and from then on every `get_setting()` returns `false` and every `get_quiz_options()` an empty object. Nothing errors loudly, so it shows up as a page that renders wrong rather than an error.

## What was actually breaking

| Where | Effect |
|---|---|
| `class-qsm-results-pages.php` `load_pages()` / `convert_to_new_system()` | no `message_after` to load, so a page with `'page' => null` was pushed and became the default - the results body rendered **empty** even though the answers had loaded |
| `class-qmn-quiz-manager.php` `display_shortcode()` | the `has_proper_quiz()` gate returned before the `result_id` branch could run, so a result link showed "It appears that this quiz is not set up correctly." |
| `admin-results-details-page.php` | the quiz post is gone, so the author check could not pass and the function did a silent `return;` - a blank tab for any user without `delete_others_qsm_quizzes`; `$quiz_options['comment_section']` was also an array offset on `false` |
| `class-qmn-plugin-helper.php` `convert_to_preferred_date_format()` | undefined property + array offset on null warnings |

## The fix

A stored result is self contained, so rendering it should not need its quiz. Each of those four call sites now copes with the quiz being gone:

- **`class-qsm-results-pages.php`** - `load_pages()` returns no pages when the quiz row is gone, and `convert_to_new_system()` bails on a missing row (which also removes the null offset warning and a pointless `$wpdb->update()` against a row that no longer exists). `generate_pages()` then keeps its own existing `$default = '%QUESTIONS_ANSWERS%'` and the questions and answers render. The **row** is what is tested, not the `message_after` column, because `class-qsm-install.php:2113` does `MODIFY message_after LONGTEXT` without repeating `NOT NULL`, so that column is nullable on upgraded installs and a live quiz must not be mistaken for a deleted one.
- **`class-qmn-quiz-manager.php`** - `display_shortcode()` no longer returns early when `?result_id=` is present **and the quiz row is genuinely gone**. A quiz that is only in the trash still reports "This quiz is no longer available", exactly as before.
- **`admin-results-details-page.php`** - the silent `return;` is replaced with the styled notice already used for a missing result, `$quiz_options` is guarded with `is_array()`, and a warning notice explains that the quiz was deleted so support can tell that apart from corrupted data.
- **`class-qmn-plugin-helper.php`** - the quiz options read in `convert_to_preferred_date_format()` is guarded; it already fell back to the WordPress date format.

`prepare_quiz()` itself is deliberately unchanged - its `false` return is correct and other callers depend on it.

## Access

Nothing is widened. The result branch delegates to `[qsm_result]`, whose permission check is the `result_link_visibility` setting plus user ownership and is entirely quiz independent - that shortcode was already reachable on its own without passing through `has_proper_quiz()`. On the admin side the change only makes an existing denial explicit; a user still needs `delete_others_qsm_quizzes` to view a result whose quiz is gone.

## Test

1. Create a quiz, submit a few results, note their `result_id` and `unique_id`.
2. Delete the quiz **from the database**.
3. Admin -> Results -> the results are still listed; opening one shows the header, score, questions and answers, with a "quiz has been deleted" notice and **no** PHP warnings (`WP_DEBUG` on).
4. `[qsm_result id="<result_id>"]` on any page renders the answers instead of an empty box.
5. `[qsm_quiz quiz="<deleted id>"]` with `?result_id=<unique_id>` renders the result.
6. Repeat with a legacy format result (non empty `quiz_results` column) as well as a new format one.
7. `SELECT COUNT(*) FROM wp_mlw_results WHERE quiz_id = <deleted id>` is unchanged throughout - nothing here deletes data.

## Not covered

`%RESULT_LINK%` points at the quiz post permalink, and a permanent delete force deletes that post, so a previously shared link 404s at the WordPress level before any plugin code runs. Fixing that needs a standalone route (something like `?qsm_result=<unique_id>`) or not force deleting the post when the quiz has results - a separate decision.

Reviewed by a second model before opening; its two actionable findings (the nullable `message_after` column, and keeping trashed quizzes behaving as before) are folded into the second commit.

Not verified by running PHP: there is no PHP runtime in this session, so this needs a sandbox pass before merge.

Agentric session: https://ai.expresstech.io/#/sessions/aos-ses_c75449303975ac44