### PR TITLE
Show the stored answer when a result question is no longer in the quiz

### DIFF
--- a/php/template-variables.php
+++ b/php/template-variables.php
@@ -1626,11 +1626,17 @@ function qsm_questions_answers_shortcode_to_text( $mlw_quiz_array, $qmn_question
 			// unpublished, or taken off every page. Its options cannot be listed any
 			// more, but what the user answered is stored on the result itself, so show
 			// that rather than leaving the question with an empty answer.
-			$stored_answer = isset( $answer[1] ) ? (string) $answer[1] : '';
-			if ( '' === trim( str_replace( ',', '', wp_strip_all_tags( $stored_answer ) ) ) && isset( $quiz_options->no_answer_text ) ) {
-				$stored_answer = $quiz_options->no_answer_text;
+			$stored_answer  = isset( $answer[1] ) ? (string) $answer[1] : '';
+			$file_extension = substr( $stored_answer, -4 );
+			if ( isset( $answer['question_type'] ) && 11 == $answer['question_type'] && in_array( $file_extension, array( '.jpg', 'jpeg', '.png', '.gif' ), true ) ) {
+				// An uploaded image is still an image, so keep showing it as one.
+				$question_with_answer_text .= $open_span_tag . '<img src="' . esc_url( $stored_answer ) . '"/></span>';
+			} else {
+				if ( '' === trim( str_replace( ',', '', wp_strip_all_tags( $stored_answer ) ) ) && isset( $quiz_options->no_answer_text ) ) {
+					$stored_answer = $quiz_options->no_answer_text;
+				}
+				$question_with_answer_text .= $open_span_tag . preg_replace( "/[\n\r]+/", '', nl2br( htmlspecialchars_decode( $stored_answer, ENT_QUOTES ) ) ) . '</span>';
 			}
-			$question_with_answer_text .= $open_span_tag . preg_replace( "/[\n\r]+/", '', nl2br( htmlspecialchars_decode( $stored_answer, ENT_QUOTES ) ) ) . '</span>';
 		}
 		$mlw_question_answer_display = str_replace( '%USER_ANSWERS_DEFAULT%', do_shortcode( $question_with_answer_text ), $mlw_question_answer_display );
 		$mlw_question_answer_display = str_replace( '%USER_ANSWER%', do_shortcode( $question_with_answer_text ), $mlw_question_answer_display );

--- a/php/template-variables.php
+++ b/php/template-variables.php
@@ -1621,6 +1621,16 @@ function qsm_questions_answers_shortcode_to_text( $mlw_quiz_array, $qmn_question
 					$question_with_answer_text .= '<span class="qsm-user-answer-text">' . preg_replace( "/[\n\r]+/", '', nl2br( htmlspecialchars_decode( $answer[1], ENT_QUOTES ) ) ) . '</span>';
 					$question_with_answer_text = apply_filters( 'qsm_result_page_answer_text_with_no_answer', $question_with_answer_text, $total_answers, $questions, $answer );
 			}
+		} else {
+			// The question is no longer part of the quiz: deleted from the database,
+			// unpublished, or taken off every page. Its options cannot be listed any
+			// more, but what the user answered is stored on the result itself, so show
+			// that rather than leaving the question with an empty answer.
+			$stored_answer = isset( $answer[1] ) ? (string) $answer[1] : '';
+			if ( '' === trim( str_replace( ',', '', wp_strip_all_tags( $stored_answer ) ) ) && isset( $quiz_options->no_answer_text ) ) {
+				$stored_answer = $quiz_options->no_answer_text;
+			}
+			$question_with_answer_text .= $open_span_tag . preg_replace( "/[\n\r]+/", '', nl2br( htmlspecialchars_decode( $stored_answer, ENT_QUOTES ) ) ) . '</span>';
 		}
 		$mlw_question_answer_display = str_replace( '%USER_ANSWERS_DEFAULT%', do_shortcode( $question_with_answer_text ), $mlw_question_answer_display );
 		$mlw_question_answer_display = str_replace( '%USER_ANSWER%', do_shortcode( $question_with_answer_text ), $mlw_question_answer_display );


### PR DESCRIPTION
## The problem

Delete a question permanently from a quiz and the results that contain it stop showing that question's answer. The question title still prints, the answer block is blank.

This is **not** data loss. `qsm_delete_question_from_database()` (`php/admin/options-page-questions-tab.php:1447`) only deletes from `mlw_questions`, and `QMNPluginHelper::get_formated_result_data()` reads `qsm_results_questions` with no join to it, so the stored answers are all still there.

## The cause

In `qsm_questions_answers_shortcode_to_text()` (`php/template-variables.php`), the whole `%USER_ANSWERS_DEFAULT%` body is wrapped in

```php
if ( isset( $answer['id'] ) && isset( $questions[ $answer['id'] ] ) && ! empty( $questions[ $answer['id'] ] ) ) {
```

with no `else`, where `$questions` comes from the **live** `QSM_Questions::load_questions_by_pages( $quiz_id )`. `$question_with_answer_text` is initialised to `''`, so when the question is gone `%USER_ANSWERS_DEFAULT%` and `%USER_ANSWER%` are both replaced with an empty string. That variable is in the default template (`%QUESTION%<br/>%USER_ANSWERS_DEFAULT%`), so every quiz using the default is affected.

The same blank answer appears for a question that is merely **unpublished** or **taken off every page**, not only a permanently deleted one: `load_questions_by_pages()` reads the quiz's `pages` setting, and `get_quiz_setting( 'pages', ..., '' )` drops unpublished questions (`php/classes/class-qmn-plugin-helper.php:317-329`).

## The fix

An `else` that renders the answer stored on the result row (`$answer[1]`), using the same `$open_span_tag` / `htmlspecialchars_decode` / `nl2br` pattern as the sibling branches in the same function, and the quiz's "no answer" text when it is blank. An uploaded image answer (question type 11) keeps rendering as an image rather than a raw URL.

The option list cannot be rebuilt - that data only ever lived on the question - but what the user actually answered is shown instead of nothing.

This also covers `%QUESTION_ANSWER_<id>%` (`qsm_variable_single_question_answer`, `php/template-variables.php:209`), which renders through the same function.

## Test

1. Create a quiz with a multiple choice question and a file upload question, submit a result.
2. Confirm the result renders normally, on the results page and under Results -> view details.
3. Delete both questions permanently from the Questions tab.
4. Re-open the same result: each question still shows its title and the answer the user gave (the image still renders as an image), instead of a blank answer block.
5. Repeat with a question that is only **unpublished** rather than deleted - same expectation.
6. Sanity check a normal quiz with all its questions intact: the full option list still renders exactly as before, since the new branch is only reachable when the question is missing.

Reviewed by a second model before opening. Its one actionable finding (file upload answers degrading to plain text) is folded into the second commit; it also flagged the comment wording about unpublished questions, which I checked and kept - that path really does drop them, via the `pages` filter linked above.

Not verified by running PHP: there is no PHP runtime in this session, so this needs a sandbox pass before merge.

Related: #3245 (the same class of bug for a deleted quiz).

Agentric session: https://ai.expresstech.io/#/sessions/aos-ses_c75449303975ac44